### PR TITLE
[Bugfix] Correct condition to check presence in renderDoFrameTag

### DIFF
--- a/ui/src/lynx_perf/frame/render_doframe_mark.ts
+++ b/ui/src/lynx_perf/frame/render_doframe_mark.ts
@@ -53,7 +53,7 @@ export function renderDoFrameTag(
     ctx.arc(x, y, radius, 0, 2 * Math.PI);
     ctx.closePath();
 
-    if (lynxPerfGlobals.state.filteredTraceSet.has(value.id) !== undefined) {
+    if (lynxPerfGlobals.state.filteredTraceSet.has(value.id)) {
       ctx.fillStyle = UNEXPECTED_PINK.disabled.cssString;
     } else {
       ctx.fillStyle =


### PR DESCRIPTION
Summary of change:
Fixed a bug in the renderDoFrameTag  where the condition incorrectly checked if `filteredTraceSet.has(value.id)` was not undefined. Since `.has()` returns a boolean, the condition is updated to directly use its boolean result.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
