### PR TITLE
[BugFix] replace opt.value() with *opt after has_value() check for iOS < 12.0 compatibility

### DIFF
--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -407,7 +407,7 @@ base::Status SetFilePermissions(const std::string& file_path,
         "The chmod mode bits must be a 4-digit octal number, e.g. 0660");
   }
   if (PERFETTO_EINTR(
-          chmod(file_path.c_str(), static_cast<mode_t>(mode_value.value())))) {
+          chmod(file_path.c_str(), static_cast<mode_t>(*mode_value)))) {
     return base::ErrStatus("Failed to chmod %s", file_path.c_str());
   }
   return base::OkStatus();

--- a/src/base/subprocess_posix.cc
+++ b/src/base/subprocess_posix.cc
@@ -83,7 +83,7 @@ void __attribute__((noreturn)) ChildProcess(ChildProcessArgs* args) {
   };
 
   if (args->create_args->posix_proc_group_id.has_value()) {
-    if (setpgid(0 /*self*/, args->create_args->posix_proc_group_id.value())) {
+    if (setpgid(0 /*self*/, *(args->create_args->posix_proc_group_id))) {
       die("setpgid() failed");
     }
   }

--- a/src/tracing/console_interceptor.cc
+++ b/src/tracing/console_interceptor.cc
@@ -155,10 +155,10 @@ ConsoleInterceptor::Delegate::GetSessionState() {
   // kept locked) until we return from OnTracePacket. This avoids having to lock
   // and unlock the instance multiple times per invocation.
   if (locked_self_.has_value())
-    return &locked_self_.value()->session_state_;
+    return &(*locked_self_)->session_state_;
   locked_self_ =
       std::make_optional<SelfHandle>(context_.GetInterceptorLocked());
-  return &locked_self_.value()->session_state_;
+  return &(*locked_self_)->session_state_;
 }
 
 void ConsoleInterceptor::Delegate::OnTrackUpdated(

--- a/src/tracing/internal/track_event_internal.cc
+++ b/src/tracing/internal/track_event_internal.cc
@@ -428,11 +428,13 @@ void TrackEventInternal::ResetIncrementalState(
     // with boot time.
     // TODO(leszeks): Consider allowing synchronization against other clocks
     // than boot time.
-    static os_log_t log_handle = os_log_create(
-        "dev.perfetto.clock_sync", OS_LOG_CATEGORY_POINTS_OF_INTEREST);
-    os_signpost_event_emit(
-        log_handle, OS_SIGNPOST_ID_EXCLUSIVE, "boottime", "%" PRId64,
-        static_cast<uint64_t>(perfetto::base::GetBootTimeNs().count()));
+    if (__builtin_available(macOS 10.14, *)) {
+      static os_log_t log_handle = os_log_create(
+          "dev.perfetto.clock_sync", OS_LOG_CATEGORY_POINTS_OF_INTEREST);
+      os_signpost_event_emit(
+          log_handle, OS_SIGNPOST_ID_EXCLUSIVE, "boottime", "%" PRId64,
+          static_cast<uint64_t>(perfetto::base::GetBootTimeNs().count()));
+    }
 #endif
 
     if (tls_state.default_clock != static_cast<uint32_t>(GetClockId())) {

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -2657,7 +2657,7 @@ void TracingServiceImpl::MaybeFilterPackets(TracingSession* tracing_session,
       // Keep the per-buffer stats updated. Also propagate the
       // buffer_index_for_stats in the output packet to allow accounting by
       // other parts of the ReadBuffer pipeline.
-      uint32_t buffer_idx = maybe_buffer_idx.value();
+      uint32_t buffer_idx = *maybe_buffer_idx;
       packet.set_buffer_index_for_stats(buffer_idx);
       auto& vec = tracing_session->filter_bytes_discarded_per_buffer;
       if (static_cast<size_t>(buffer_idx) >= vec.size())
@@ -3927,7 +3927,7 @@ void TracingServiceImpl::MaybeEmitCloneTrigger(
   if (tracing_session->clone_trigger.has_value()) {
     protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
     auto* trigger = packet->set_clone_snapshot_trigger();
-    const auto& info = tracing_session->clone_trigger.value();
+    const auto& info = *(tracing_session->clone_trigger);
     trigger->set_trigger_name(info.trigger_name);
     trigger->set_producer_name(info.producer_name);
     trigger->set_trusted_producer_uid(static_cast<int32_t>(info.producer_uid));


### PR DESCRIPTION
- opt.value() is unavailable on iOS versions below 12.0 due to libc++ limitations
- Using *opt after has_value() check ensures compatibility with older iOS systems
- Improves code portability and prevents build errors on legacy devices
