### PR TITLE
[Refactor] Adjust argument order in ThreadSliceDetailsPanel

### DIFF
--- a/ui/src/components/details/thread_slice_details_tab.ts
+++ b/ui/src/components/details/thread_slice_details_tab.ts
@@ -285,7 +285,7 @@ export class ThreadSliceDetailsPanel implements TrackEventDetailsPanel {
     const description = this.renderDescription();
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (description ?? precFlows ?? followingFlows ?? args) {
-      return m(GridLayoutColumn, precFlows, followingFlows, args, description);
+      return m(GridLayoutColumn, args, description, precFlows, followingFlows);
     } else {
       return undefined;
     }


### PR DESCRIPTION
Summary of change:
Reordered the arguments passed to `GridLayoutColumn` in `ThreadSliceDetailsPanel` to improve consistency or rendering logic. Specifically, moved `args` and `description` before `precFlows` and `followingFlows`. This change does not affect functionality but aims to clarify the layout structure and maintain consistency in argument ordering.

Changes include:
- Updated argument order in render method from `(precFlows, followingFlows, args, description)` to `(args, description, precFlows, followingFlows)`.

