### PR TITLE
[BugFix] Hide "Visualize argument values" entry for "instance_id" arg…

### DIFF
--- a/ui/src/components/details/slice_args.ts
+++ b/ui/src/components/details/slice_args.ts
@@ -110,13 +110,16 @@ function renderArgKey(trace: Trace, key: string, value?: Arg): m.Children {
           });
         },
       }),
-      m(MenuItem, {
-        label: 'Visualize argument values',
-        icon: 'query_stats',
-        onclick: () => {
-          extensions.addVisualizedArgTracks(trace, fullKey);
-        },
-      }),
+      (lynxPerfGlobals.state.lynxviewInstances.length <= 0 ||
+        (fullKey !== 'debug.instance_id' && fullKey !== 'args.instance_id') ||
+        !displayValue) &&
+        m(MenuItem, {
+          label: 'Visualize argument values',
+          icon: 'query_stats',
+          onclick: () => {
+            extensions.addVisualizedArgTracks(trace, fullKey);
+          },
+        }),
       lynxPerfGlobals.state.lynxviewInstances.length > 0 &&
         (fullKey === 'debug.instance_id' || fullKey === 'args.instance_id') &&
         displayValue != null &&


### PR DESCRIPTION
… key

Summary of the change:

The 'Focus LynxView' plugin introduces an 'instance_id' table, where every trace event with an ancestor containing the 'instance_id' arg key is also assigned this key and inserted into the table. This can result in a large number of trace events with the 'instance_id' arg key. Consequently, the "Visualize argument values" feature for the 'instance_id' arg key can become very costly due to extensive searches in the `ancestor_slice($id)` table. To optimize this, we now use the 'Focus LynxView' feature to replace "Visualize argument values" for this specific key, and have therefore hidden the "Visualize argument values" entry for the 'instance_id' arg key.
