### PR TITLE
[Optimize] Update BufferExhaustedPolicy to kStall and adjust stall behavior for Lynx Trace

### DIFF
--- a/include/perfetto/tracing/internal/track_event_data_source.h
+++ b/include/perfetto/tracing/internal/track_event_data_source.h
@@ -231,6 +231,8 @@ class TrackEventDataSource
  public:
   static constexpr bool kRequiresCallbacksUnderLock = false;
 
+  constexpr static BufferExhaustedPolicy kBufferExhaustedPolicy =
+      BufferExhaustedPolicy::kStall;
   // Add or remove a session observer for this track event data source. The
   // observer will be notified about started and stopped tracing sessions.
   // Returns |true| if the observer was successfully added (i.e., the maximum

--- a/sdk/perfetto.cc
+++ b/sdk/perfetto.cc
@@ -34938,12 +34938,14 @@ Chunk SharedMemoryArbiterImpl::GetNewChunk(
 
     if (stall_count == kAssertAtNStalls) {
       Stats stats = GetStats();
-      PERFETTO_FATAL(
+      // stall too many times, just return invalid Chunk.
+      PERFETTO_ELOG(
           "Shared memory buffer max stall count exceeded; possible deadlock "
           "free=%zu bw=%zu br=%zu comp=%zu pages_free=%zu pages_err=%zu",
           stats.chunks_free, stats.chunks_being_written,
           stats.chunks_being_read, stats.chunks_complete, stats.pages_free,
           stats.pages_unexpected);
+      return Chunk();
     }
 
     // If the IPC thread itself is stalled because the current process has
@@ -44212,8 +44214,8 @@ const char* GetVersionCode();
 #ifndef GEN_PERFETTO_VERSION_GEN_H_
 #define GEN_PERFETTO_VERSION_GEN_H_
 
-#define PERFETTO_VERSION_STRING() "v50.1-387e5a479"
-#define PERFETTO_VERSION_SCM_REVISION() "387e5a47915a0d97793d9cd286e23f32c08c3f1b"
+#define PERFETTO_VERSION_STRING() "v50.1-76755c674"
+#define PERFETTO_VERSION_SCM_REVISION() "76755c6749e1308f57bc00394e66faf188a70810"
 
 #endif  // GEN_PERFETTO_VERSION_GEN_H_
 /*

--- a/src/tracing/core/shared_memory_arbiter_impl.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl.cc
@@ -195,12 +195,14 @@ Chunk SharedMemoryArbiterImpl::GetNewChunk(
 
     if (stall_count == kAssertAtNStalls) {
       Stats stats = GetStats();
-      PERFETTO_FATAL(
+      // stall too many times, just return invalid Chunk.
+      PERFETTO_ELOG(
           "Shared memory buffer max stall count exceeded; possible deadlock "
           "free=%zu bw=%zu br=%zu comp=%zu pages_free=%zu pages_err=%zu",
           stats.chunks_free, stats.chunks_being_written,
           stats.chunks_being_read, stats.chunks_complete, stats.pages_free,
           stats.pages_unexpected);
+      return Chunk();
     }
 
     // If the IPC thread itself is stalled because the current process has


### PR DESCRIPTION
Summary:
1. Changed Lynx Trace BufferExhaustedPolicy to kStall. When Shared Memory Buffer (SMB) is exhausted, Trace now stalls and waits (up to 100ms) for buffer space to free up, reducing trace data loss.
2. Previously, exceeding the stall count led to app crashes, which is unreasonable; ideally, trace data should be dropped rather than forcing a crash.
