### PR TITLE
[Optimize] Refine the logic for determining whether to display Lynx FCP

### DIFF
--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -631,6 +631,12 @@ base::Status TrackEventTokenizer::HandleExtraArgsValues(
         pipeline_id = "";
         timing_flag = "";
       }
+      if (!pipeline_id.empty() &&
+          event.name().ToStdString() == "Timing::Mark.loadBundleStart") {
+        context_->storage->AddPipelineFlag(pipeline_id, "Lynx FCP");
+        pipeline_id = "";
+      }
+
       if (!instance_id.empty() && !url.empty()) {
         context_->storage->SetInstanceUrl(instance_id, url);
         instance_id = "";


### PR DESCRIPTION
Currently, the display logic for the Lynx FCP marker is as follows: When a `Timing::Mark.paintEnd` trace event has no `timing_flags` and the current pipeline has a `Timing::Mark.loadBundleStart` event, the Lynx FCP is displayed. However, this approach has a drawback: if the first frame contains business-related timing_flags, the Lynx FCP will not be shown.

Our goal is to ensure that Lynx FCP is displayed for the first frame of every LynxView. To achieve this, we add Lynx FCP timing flags to the pipeline corresponding to `Timing::Mark.loadBundleStart` and remove the front-end SQL query logic.
