### PR TITLE
[Optimize] UI improvements for NativeModule track

### DIFF
--- a/ui/src/lynx_perf/constants.ts
+++ b/ui/src/lynx_perf/constants.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {HSLColor} from '../base/color';
+
 // Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
@@ -78,6 +80,23 @@ export const NATIVEMODULE_PLATFORM_METHOD_END =
   'JSBTiming::jsb_func_platform_method_end';
 export const NATIVEMODULE_TIMING_FLUSH = 'JSBTiming::Flush';
 export const NATIVEMODULE_NETWORK_REQUEST = 'Network::SendNetworkRequest';
+export const NATIVEMODULE_INVOKE = 'NativeModule::Invoke';
+export const NATIVEMODULE_INVOKE_LIST = [
+  NATIVEMODULE_CALL,
+  DEPRECATED_NATIVEMODULE_CALL,
+  NATIVEMODULE_INVOKE,
+];
+export const NATIVEMODULE_PLATFORM_CALLBACK_START =
+  'NativeModule::PlatformCallbackStart';
+export const NATIVEMODULE_CALLBACK = 'NativeModule::Callback';
+export const NATIVEMODULE_EVENTS_WITH_FLOW_ID_LIST = [
+  NATIVEMODULE_INVOKE,
+  NATIVEMODULE_PLATFORM_CALLBACK_START,
+  NATIVEMODULE_CALLBACK,
+];
+export const THREAD_UNKNOWN = '/';
+export const DASHED_AREA_COLOR = new HSLColor([0, 0, 95]);
+
 // Frame Jank
 export const DROP_FRAME_THRESHOLD = 16666666;
 

--- a/ui/src/lynx_perf/empty_state.ts
+++ b/ui/src/lynx_perf/empty_state.ts
@@ -26,6 +26,8 @@ export function createEmptyLynxState(): LynxState {
     traceIdToJSBName: new Map(),
     traceIdToScrollName: new Map(),
     trackUriToThreadMap: new Map(),
+    // From Lynx 3.4, we delete trace events for NativeModule timing.
+    nonTimingNativeModuleTraces: false,
     frameDurationMap: new Map(),
     highlightNoInstanceIdTrace: true,
     lynxviewInstances: [],

--- a/ui/src/lynx_perf/lynx_base_track.ts
+++ b/ui/src/lynx_perf/lynx_base_track.ts
@@ -246,6 +246,49 @@ export abstract class LynxBaseTrack<T extends BaseSlice[]>
     renderCtx.closePath();
   }
 
+  /**
+   * Draws a rounded thick border around a rectangular area
+   * @param ctx - Track rendering context
+   * @param x - Horizontal position
+   * @param y - Vertical position
+   * @param width - Border width
+   * @param height - Border height
+   * @param colorSchema - Color scheme to use
+   * @param radius - Radius of rounded corners
+   */
+  protected drawRoundThickBorder(
+    ctx: TrackRenderContext,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    colorSchema: ColorScheme,
+    radius: number,
+  ) {
+    const renderCtx = ctx.ctx;
+    renderCtx.strokeStyle = colorSchema.base.setHSL({s: 100, l: 10}).cssString;
+    const THICKNESS = 3;
+    renderCtx.lineWidth = THICKNESS;
+    renderCtx.beginPath();
+    renderCtx.moveTo(x + radius, y);
+    renderCtx.lineTo(x + width - radius, y);
+    renderCtx.arcTo(x + width, y, x + width, y + radius, radius);
+    renderCtx.lineTo(x + width, y + height - radius);
+    renderCtx.arcTo(
+      x + width,
+      y + height,
+      x + width - radius,
+      y + height,
+      radius,
+    );
+    renderCtx.lineTo(x + radius, y + height);
+    renderCtx.arcTo(x, y + height, x, y + height - radius, radius);
+    renderCtx.lineTo(x, y + radius);
+    renderCtx.arcTo(x, y, x + radius, y, radius);
+    renderCtx.closePath();
+    renderCtx.stroke();
+  }
+
   async getSelectionDetails(
     id: number,
   ): Promise<TrackEventDetails | undefined> {

--- a/ui/src/lynx_perf/lynx_perf_globals.ts
+++ b/ui/src/lynx_perf/lynx_perf_globals.ts
@@ -54,6 +54,12 @@ class LynxPerfGlobals {
     });
   }
 
+  setNonTimingNativeModuleTraces(nonTimingNativeModuleTraces: boolean) {
+    this._store.edit((draft) => {
+      draft.nonTimingNativeModuleTraces = nonTimingNativeModuleTraces;
+    });
+  }
+
   updateVitalTimestampLine(timestamp: VitalTimestampLine[]) {
     this._store.edit((draft) => {
       draft.vitalTimestampLine = timestamp;

--- a/ui/src/lynx_perf/types.ts
+++ b/ui/src/lynx_perf/types.ts
@@ -20,9 +20,13 @@ export interface LynxState {
   issues: IssueSummary[];
   vitalTimestampLine: VitalTimestampLine[];
   selectedTimestamp: number;
+
+  // NativeModule
   traceIdToJSBName: Map<number, string>;
   traceIdToScrollName: Map<number, string>;
   trackUriToThreadMap: Map<string, SliceThreadState>;
+  nonTimingNativeModuleTraces: boolean;
+
   frameDurationMap: Map<number, FrameSlice>;
 
   highlightNoInstanceIdTrace: boolean;

--- a/ui/src/plugins/lynx.focusMode/index.ts
+++ b/ui/src/plugins/lynx.focusMode/index.ts
@@ -22,10 +22,9 @@ import {NUM, STR} from '../../trace_processor/query_result';
 import {
   COMMAND_FOCUS_LYNX_VIEW,
   COMMAND_QUERY_LYNX_VIEW,
-  DEPRECATED_NATIVEMODULE_CALL,
   LYNX_LOAD_BUNDLE,
   LYNX_NATIVE_MODULE_ID,
-  NATIVEMODULE_CALL,
+  NATIVEMODULE_INVOKE_LIST,
   NO_INSTANCE_ID,
   PARAMETER_FOCUS_LYNX_VIEWS,
 } from '../../lynx_perf/constants';
@@ -264,10 +263,9 @@ export default class FocusMode implements PerfettoPlugin {
         if (trackNode.uri === LYNX_NATIVE_MODULE_ID) {
           const queryRes = await trace.engine.query(
             `select 
-                    slice.id as id
-                from slice 
-                where (slice.name='${NATIVEMODULE_CALL}' or slice.name='${DEPRECATED_NATIVEMODULE_CALL}')
-                `,
+                slice.id as id
+              from slice 
+              where slice.name in (${NATIVEMODULE_INVOKE_LIST.join(',')})`,
           );
           const it = queryRes.iter({
             id: NUM,

--- a/ui/src/plugins/lynx.nativemodule/native_module_detail_view.tsx
+++ b/ui/src/plugins/lynx.nativemodule/native_module_detail_view.tsx
@@ -24,12 +24,15 @@ import {NativeModuleSection} from './types';
 import {SECTION_COLOR} from './types';
 import {TableColumnTitle} from '../../lynx_perf/common_components/table_column_title';
 import {SliceDetails} from '../../components/sql_utils/slice';
+import {THREAD_UNKNOWN} from '../../lynx_perf/constants';
 
 export interface NativeModuleDetailAttr {
   sectionDetail: NativeModuleSection[] | undefined;
   sliceDetail: SliceDetails | undefined;
 }
 
+
+const AWATIMING_CALLBACK_STAGE_DOTTED_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAeCAYAAAAsEj5rAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAomVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAJAAAAABAAAAkAAAAAEABJKGAAcAAAASAAAAkKABAAMAAAABAAEAAKACAAQAAAABAAAAFKADAAQAAAABAAAAHgAAAABBU0NJSQAAAFNjcmVlbnNob3R+Qvo8AAAACXBIWXMAABYlAAAWJQFJUiTwAAADBGlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczpleGlmPSJodHRwOi8vbnMuYWRvYmUuY29tL2V4aWYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8ZXhpZjpQaXhlbFhEaW1lbnNpb24+MTY4PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6Q29sb3JTcGFjZT4xPC9leGlmOkNvbG9yU3BhY2U+CiAgICAgICAgIDxleGlmOlVzZXJDb21tZW50PlNjcmVlbnNob3Q8L2V4aWY6VXNlckNvbW1lbnQ+CiAgICAgICAgIDxleGlmOlBpeGVsWURpbWVuc2lvbj45MjwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDx0aWZmOllSZXNvbHV0aW9uPjE0NDwvdGlmZjpZUmVzb2x1dGlvbj4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+MTQ0PC90aWZmOlhSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KE9AuzQAAAUxJREFUSA3tlttqhDAQhicxHkC9EPH9H1BEEBVBcds/ZdpkN4kuTe8aCLvO4TOTzEwU0zQ9KDDGcdTauq5JKRWw/FIFLQDDPI5Dz6ZpLqHS90oTBpvnZ5+fE+hyLsuSrsJeloVegD5Y27ZUFIVvYQTYMAw28Lewbdt+gDFgWL4OORZMA2PCcHASQOQZDwjvHgD2jAf7yXdhDDB/GYYsUFVV0TzPZApNY9d/2GIgTZIksSISn8LHuq6U53kwz1zgfd9JCGGVo7hqDi5QSPZSKSHjO7p/4J1dCtv83R4ip8yqCa/D1qIXchnqO4Wb43me1HWdrhrbxf/EzQWFgR6gGMZv6Ptee3N5+VH2PcPRSdQjw+CcpqmuzxAIOl4ZgyDLsoykCbvbIFwwXLGY36ccA4YPAQ2MBUPYMiZMA6/aPYxCe/b8vSNDl/e7MNh/AM36Jw58d0vHAAAAAElFTkSuQmCC';
 export class NativeModuleDetailView
   implements m.ClassComponent<NativeModuleDetailAttr>
 {
@@ -67,6 +70,10 @@ export class DetailViewPanel extends Component<NativeModuleDetailAttr> {
       .join('\n');
   }
 
+  private awatingCallbackStage(thread: string, sectionIndex: number) {
+    return thread === THREAD_UNKNOWN  && sectionIndex === 2;
+  }
+
   render() {
     const {sectionDetail, sliceDetail} = this.props;
     if (!sectionDetail || !sliceDetail) {
@@ -86,16 +93,24 @@ export class DetailViewPanel extends Component<NativeModuleDetailAttr> {
         dataIndex: 'name',
         key: 'name',
         width: 150,
-        render: (value: string, _record: unknown, index: number) => (
+        render: (value: string, record: typeof stagDetailDataSource[0], index: number) => (
           <div style={{display: 'flex', alignItems: 'center'}}>
-            <div
+            {!this.awatingCallbackStage(record.thread, index) && 
+              <div
               style={{
                 width: 10,
                 height: 15,
                 backgroundColor: SECTION_COLOR[index],
                 marginRight: 5,
                 flexShrink: 0,
-              }}></div>
+              }}>
+              </div>
+            }
+            {
+              this.awatingCallbackStage(record.thread, index) && 
+              <img src={AWATIMING_CALLBACK_STAGE_DOTTED_IMAGE} style={{width:10, height:15, marginRight: 5,
+                flexShrink: 0,}}/>
+            }
             <div>{value}</div>
           </div>
         ),
@@ -139,7 +154,7 @@ export class DetailViewPanel extends Component<NativeModuleDetailAttr> {
         <ConfigProvider
           theme={{
             token: {
-              colorBgContainer: '#ECEFF1',
+              colorBgContainer: '#ffffff',
             },
           }}>
           <Table

--- a/ui/src/plugins/lynx.nativemodule/tracks.ts
+++ b/ui/src/plugins/lynx.nativemodule/tracks.ts
@@ -42,6 +42,10 @@ import {
   SLICE_LAYOUT_FIT_CONTENT_DEFAULTS,
   NATIVEMODULE_PLATFORM_METHOD_END,
   NATIVEMODULE_CALLBACK_INVOKE_END,
+  NATIVEMODULE_INVOKE,
+  NATIVEMODULE_CALLBACK,
+  NATIVEMODULE_THREAD_SWITCH_END,
+  DASHED_AREA_COLOR,
 } from '../../lynx_perf/constants';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {NativeModuleDetailsPanel} from './details';
@@ -49,8 +53,8 @@ import {AppImpl} from '../../core/app_impl';
 import {getColorForSlice, UNEXPECTED_PINK} from '../../components/colorizer';
 import {formatDuration} from '../../components/time_utils';
 import {isNativeModuleCall} from './utils';
-
-export const NATIVE_MODULE_FLOW_COUNT = 15;
+import {stringToJsonObject} from '../../lynx_perf/string_utils';
+import {HSLColor} from '../../base/color';
 
 const SLICE_HEIGHT = SLICE_LAYOUT_FIT_CONTENT_DEFAULTS.sliceHeight;
 const SLICE_PADDING = SLICE_LAYOUT_FIT_CONTENT_DEFAULTS.padding;
@@ -71,6 +75,9 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
   protected maxSliceDepth = 0;
   private charWidth = -1;
   private colorSchema = UNEXPECTED_PINK;
+  readonly rootTableName = 'slice';
+  private readonly TEXT_COLOR_BLACK = new HSLColor([0, 0, 0]);
+  private readonly TEXT_COLOR_WHITE = new HSLColor([0, 0, 100]);
 
   /**
    * Calculates track height based on slice depth
@@ -95,6 +102,9 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
     _end: time,
     _resolution: duration,
   ): Promise<NativeModuleItem[]> {
+    if (lynxPerfGlobals.state.nonTimingNativeModuleTraces) {
+      return await this.getNonTimingNativeModuleItems();
+    }
     const queryRes = await this.trace.engine.query(
       `select 
       slice.ts as ts, 
@@ -109,7 +119,7 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
       from slice 
       inner join args on args.arg_set_id = slice.arg_set_id
       where (slice.name='${NATIVEMODULE_FUNC_CALL_START}' or slice.name='${NATIVEMODULE_CALL}' or slice.name='${DEPRECATED_NATIVEMODULE_CALL}' or slice.name='${NATIVEMODULE_NETWORK_REQUEST}' 
-      or slice.name='${NATIVEMODULE_PLATFORM_METHOD_END}' or slice.name='${NATIVEMODULE_CALLBACK_INVOKE_END}') order by ts ASC
+      or slice.name='${NATIVEMODULE_PLATFORM_METHOD_END}' or slice.name='${NATIVEMODULE_CALLBACK_INVOKE_END}' or slice.name='${NATIVEMODULE_THREAD_SWITCH_END}') order by ts ASC
       `,
     );
     const it = queryRes.iter({
@@ -151,6 +161,8 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
           methodName: '',
           firstArg: '',
           url: '',
+          invokeEndTs: it.ts + it.dur,
+          callbackStartTs: 0,
         });
       }
 
@@ -177,6 +189,17 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
         const startJSB = traceIdToJSBMap.get(startJSBTraceId);
         if (startJSB !== undefined) {
           startJSB.dur = nativeModuleEndTs - startJSB.ts;
+        }
+      }
+      if (
+        it.key === 'debug.flowId' &&
+        it.name === NATIVEMODULE_THREAD_SWITCH_END
+      ) {
+        const flowId = Number(it.intValue);
+        const startJSBTraceId = flowIdToTraceIdMap.get(flowId);
+        const startJSB = traceIdToJSBMap.get(startJSBTraceId);
+        if (startJSB !== undefined) {
+          startJSB.callbackStartTs = it.ts;
         }
       }
 
@@ -225,6 +248,145 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
         sections: [],
         tooltip: `${name} - [${duration}]`,
         depth: this.calculateDepth(depthRange, item.ts, item.dur),
+        invokeEndTs: item.invokeEndTs,
+        callbackStartTs: item.callbackStartTs,
+      });
+      lynxPerfGlobals.addTraceIdToJSBName(item.id, name);
+    });
+    traceIdToJSBMap.clear();
+    flowIdToTraceIdMap.clear();
+    return data;
+  }
+
+  private async getNonTimingNativeModuleItems(): Promise<NativeModuleItem[]> {
+    const queryRes = await this.trace.engine.query(
+      `select 
+      slice.ts as ts, 
+      slice.id as id,
+      slice.dur as dur,
+      slice.name as name, 
+      slice.arg_set_id as argSetId,
+      args.key as key,
+      args.int_value as intValue,
+      args.string_value as stringValue
+      from slice 
+      inner join args on args.arg_set_id = slice.arg_set_id
+      where (slice.name='${NATIVEMODULE_INVOKE}' or slice.name='${NATIVEMODULE_CALLBACK}' or slice.name='${NATIVEMODULE_NETWORK_REQUEST}') order by ts ASC
+      `,
+    );
+    const it = queryRes.iter({
+      argSetId: NUM,
+      ts: NUM,
+      id: NUM,
+      dur: NUM,
+      name: STR,
+      key: STR,
+      intValue: LONG_NULL,
+      stringValue: STR_NULL,
+    });
+    const data: NativeModuleItem[] = [];
+    const depthRange: DepthRange[] = [];
+
+    const traceIdToJSBMap = new Map();
+    const flowIdToTraceIdMap = new Map();
+
+    for (; it.valid(); it.next()) {
+      if (
+        it.name === NATIVEMODULE_INVOKE &&
+        traceIdToJSBMap.get(it.id) === undefined
+      ) {
+        traceIdToJSBMap.set(it.id, {
+          id: it.id,
+          ts: it.ts,
+          dur: it.dur,
+          flowId: 0,
+          sections: [],
+          depth: 0,
+          name: '', // name consists of the following four parameters
+          moduleName: '',
+          methodName: '',
+          firstArg: '',
+          url: '',
+          invokeEndTs: it.ts + it.dur, // end ts of 'NATIVEMODULE_INVOKE'
+          callbackStartTs: 0, // start ts of 'NATIVEMODULE_CALLBACK'
+        });
+      }
+
+      // update flowId
+      if (
+        it.name === NATIVEMODULE_INVOKE &&
+        it.key === 'debug.flowId' &&
+        it.intValue != null
+      ) {
+        const flowId = Number(it.intValue);
+        flowIdToTraceIdMap.set(flowId, it.id);
+        const startJSB = traceIdToJSBMap.get(it.id);
+        startJSB.flowId = flowId;
+      }
+
+      // update duration if possible
+      if (
+        it.key === 'debug.terminateFlowId' &&
+        it.name === NATIVEMODULE_CALLBACK
+      ) {
+        const callbackEndTs = it.ts + it.dur;
+        const terminateFlowId = Number(it.intValue);
+        const startJSBTraceId = flowIdToTraceIdMap.get(terminateFlowId);
+        const startJSB = traceIdToJSBMap.get(startJSBTraceId);
+        if (startJSB !== undefined) {
+          startJSB.callbackStartTs = it.ts;
+          startJSB.dur = Math.max(startJSB.dur, callbackEndTs - startJSB.ts);
+        }
+      }
+
+      if (it.name === NATIVEMODULE_INVOKE && it.key === 'debug.arg0') {
+        const sliceName = it.stringValue || '';
+        const startJSB = traceIdToJSBMap.get(it.id);
+        startJSB.firstArg = sliceName;
+      } else if (
+        it.name === NATIVEMODULE_NETWORK_REQUEST &&
+        it.key === 'debug.url'
+      ) {
+        const startJSB = traceIdToJSBMap.get(it.id);
+        startJSB.url = it.stringValue;
+        startJSB.firstArg = 'NetworkRequest';
+      } else if (it.name === NATIVEMODULE_INVOKE && it.key === 'debug.arg1') {
+        const arg1 = stringToJsonObject(it.stringValue as string);
+        if (arg1.data !== undefined && arg1.data.url !== undefined) {
+          const startJSB = traceIdToJSBMap.get(it.id);
+          startJSB.url = arg1.data.url;
+        }
+      } else if (
+        it.name === NATIVEMODULE_INVOKE &&
+        it.key === 'debug.module_name'
+      ) {
+        const startJSB = traceIdToJSBMap.get(it.id);
+        startJSB.moduleName = it.stringValue;
+      } else if (
+        it.name === NATIVEMODULE_INVOKE &&
+        it.key === 'debug.method_name'
+      ) {
+        const startJSB = traceIdToJSBMap.get(it.id);
+        startJSB.methodName = it.stringValue;
+      }
+    }
+    const sortedJsb = Array.from(traceIdToJSBMap.keys())
+      .sort((a, b) => a - b)
+      .map((key) => traceIdToJSBMap.get(key));
+    sortedJsb.forEach((item) => {
+      const duration = formatDuration(this.trace, BigInt(item.dur));
+      const name = this.assembleNativeModuleName(item);
+      data.push({
+        id: item.id,
+        ts: item.ts,
+        dur: item.dur,
+        name,
+        flowId: item.flowId,
+        sections: [],
+        tooltip: `${name} - [${duration}]`,
+        depth: this.calculateDepth(depthRange, item.ts, item.dur),
+        invokeEndTs: item.invokeEndTs,
+        callbackStartTs: item.callbackStartTs,
       });
       lynxPerfGlobals.addTraceIdToJSBName(item.id, name);
     });
@@ -316,13 +478,23 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
       yPx: 0,
       durPx: 0,
     };
+    const pxEnd = ctx.size.width;
     for (let i = 0; i < data.length; i++) {
       const slice = data[i];
       const selected = selectedId === slice.id;
       const posX = Time.fromRaw(BigInt(slice.ts));
-      const xPx = ctx.timescale.timeToPx(posX);
       const durW = Duration.fromRaw(BigInt(slice.dur ?? 0));
-      const xDur = ctx.timescale.durationToPx(durW);
+      const timePx = ctx.timescale.timeToPx(posX);
+      // The start of slice may be out of the visible window
+      const xPx = Math.max(timePx, 0);
+      const durPx =
+        ctx.timescale.durationToPx(durW) + (timePx < 0 ? timePx : 0);
+      // Only show the visible part of the slice
+      const xDur = Math.min(durPx, pxEnd - xPx);
+      if (xDur < 0) {
+        continue;
+      }
+
       this.colorSchema = getColorForSlice(slice.name);
 
       // Pass 1: fill slices by color
@@ -331,47 +503,83 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
       slice.sections = NativeModuleDataManager.getNativeModuleSections(
         slice.id,
       );
-      if (
-        selected &&
-        slice.sections != undefined &&
-        slice.sections.length > 0
-      ) {
-        for (
-          let sectionIndex = 0;
-          sectionIndex < slice.sections.length;
-          sectionIndex++
-        ) {
-          const currentSection = slice.sections[sectionIndex];
-          const xPx = ctx.timescale.timeToPx(
-            Time.fromRaw(BigInt(currentSection.beginTs)),
-          );
-          const durW = Duration.fromRaw(
-            BigInt(currentSection.endTs - currentSection.beginTs),
-          );
-          const xDur = ctx.timescale.durationToPx(durW);
-          ctx.ctx.fillStyle =
-            SECTION_COLOR[sectionIndex % SECTION_COLOR.length];
+      if (selected) {
+        if (slice.sections != undefined && slice.sections.length > 0) {
+          for (
+            let sectionIndex = 0;
+            sectionIndex < slice.sections.length;
+            sectionIndex++
+          ) {
+            const currentSection = slice.sections[sectionIndex];
+            const xPx = ctx.timescale.timeToPx(
+              Time.fromRaw(BigInt(currentSection.beginTs)),
+            );
+            const durW = Duration.fromRaw(
+              BigInt(currentSection.endTs - currentSection.beginTs),
+            );
+            const xDur = ctx.timescale.durationToPx(durW);
+            ctx.ctx.fillStyle =
+              SECTION_COLOR[sectionIndex % SECTION_COLOR.length];
+            ctx.ctx.fillRect(xPx, y, xDur, SLICE_HEIGHT);
+          }
+        } else {
+          ctx.ctx.fillStyle = lynxPerfGlobals.shouldShowSlice(slice.id)
+            ? this.colorSchema.variant.cssString
+            : this.colorSchema.disabled.cssString;
           ctx.ctx.fillRect(xPx, y, xDur, SLICE_HEIGHT);
         }
-        selectedPosition.xPx = xPx;
+        selectedPosition.xPx = timePx;
         selectedPosition.yPx = y;
-        selectedPosition.durPx = xDur;
+        selectedPosition.durPx = ctx.timescale.durationToPx(durW);
       } else {
         ctx.ctx.fillStyle = lynxPerfGlobals.shouldShowSlice(slice.id)
           ? this.colorSchema.base.cssString
           : this.colorSchema.disabled.cssString;
-        ctx.ctx.fillRect(xPx, y, xDur, SLICE_HEIGHT);
+        // ctx.ctx.fillRect(xPx, y, xDur, SLICE_HEIGHT);
+        const radius = Math.min(xDur, SLICE_HEIGHT / 4);
+        this.fillRoundRect(ctx.ctx, xPx, y, xDur, SLICE_HEIGHT, radius);
+      }
+      if (slice.callbackStartTs > slice.invokeEndTs) {
+        const otherThreadBeginTime = Time.fromRaw(BigInt(slice.invokeEndTs));
+        const timePx = ctx.timescale.timeToPx(otherThreadBeginTime);
+        const xPx = Math.max(timePx, 0);
+        const otherThreadDuration = Duration.fromRaw(
+          BigInt(slice.callbackStartTs - slice.invokeEndTs),
+        );
+        // render dashed lines area
+        const otherThreadDurationPx = Math.min(
+          ctx.timescale.durationToPx(otherThreadDuration) +
+            (timePx < 0 ? timePx : 0),
+          pxEnd - xPx,
+        );
+        ctx.ctx.fillStyle = DASHED_AREA_COLOR.cssString;
+        if (otherThreadDurationPx > 0) {
+          ctx.ctx.fillRect(xPx, y, otherThreadDurationPx, SLICE_HEIGHT);
+          this.draw45DegreeDashedLines(
+            ctx.ctx,
+            xPx,
+            y,
+            otherThreadDurationPx,
+            SLICE_HEIGHT,
+            8,
+            8,
+          );
+        }
       }
 
       // Pass 2: draw the titles
-      const textColor = selected
-        ? this.colorSchema.textVariant
-        : lynxPerfGlobals.shouldShowSlice(slice.id)
-          ? this.colorSchema.textBase
-          : this.colorSchema.textDisabled;
+      let textColor = lynxPerfGlobals.shouldShowSlice(slice.id)
+        ? this.TEXT_COLOR_WHITE
+        : this.colorSchema.textDisabled;
+      if (selected) {
+        textColor = this.colorSchema.textVariant;
+      }
+      if (slice.callbackStartTs > slice.invokeEndTs) {
+        textColor = this.TEXT_COLOR_BLACK;
+      }
       ctx.ctx.fillStyle = textColor.cssString;
       const title = cropText(slice.name, charWidth, xDur);
-      const rectXCenter = xPx + xDur / 2;
+      const rectXCenter = Math.max(xPx, 0) + xDur / 2;
       const textY =
         SLICE_PADDING + slice.depth * (SLICE_HEIGHT + SLICE_ROW_SPACING);
       const yDiv = 2;
@@ -380,17 +588,88 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
     }
 
     if (selectedPosition.durPx && selectedPosition.xPx) {
-      this.drawThickBorder(
+      this.drawRoundThickBorder(
         ctx,
         selectedPosition.xPx,
         selectedPosition.yPx,
         selectedPosition.durPx,
         SLICE_HEIGHT,
         this.colorSchema,
+        Math.min(selectedPosition.durPx, SLICE_HEIGHT / 4),
       );
     }
     ctx.ctx.fillStyle = oldStyle;
     ctx.ctx.strokeStyle = oldStrokeStyle;
+  }
+
+  /**
+    Draws a 45-degree dashed pattern within the specified rectangular area.
+    These dashed lines are usually used to indicate a special state or as a background texture.
+    @param ctx CanvasRenderingContext2D - The canvas rendering context.
+    @param x number - The X coordinate of the top-left corner of the drawing area.
+    @param y number - The Y coordinate of the top-left corner of the drawing area.
+    @param width number - The width of the drawing area.
+    @param height number - The height of the drawing area.
+    @param spacing number - The spacing between adjacent dashed lines.
+    @param dashLength number - The length of the solid segment in each dashed line.
+   */
+  private draw45DegreeDashedLines(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    spacing: number,
+    dashLength: number,
+  ) {
+    ctx.save();
+
+    ctx.beginPath();
+    ctx.rect(x, y, width, height);
+    ctx.clip();
+
+    ctx.strokeStyle = '#cccccc';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([dashLength, dashLength]);
+
+    for (let i = -height; i < width; i += spacing) {
+      ctx.beginPath();
+
+      // start point: (x + i, y + height) or (x, y + height - i)，
+      const startXLine = x + i;
+      const startYLine = y + height;
+
+      const endXLine = startXLine + height;
+      const endYLine = y;
+
+      ctx.moveTo(startXLine, startYLine);
+      ctx.lineTo(endXLine, endYLine);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+
+  fillRoundRect(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    radius: number,
+  ) {
+    ctx.beginPath();
+    ctx.moveTo(x + radius, y);
+    ctx.lineTo(x + width - radius, y);
+    ctx.arcTo(x + width, y, x + width, y + radius, radius);
+    ctx.lineTo(x + width, y + height - radius);
+    ctx.arcTo(x + width, y + height, x + width - radius, y + height, radius);
+    ctx.lineTo(x + radius, y + height);
+    ctx.arcTo(x, y + height, x, y + height - radius, radius);
+    ctx.lineTo(x, y + radius);
+    ctx.arcTo(x, y, x + radius, y, radius);
+    ctx.closePath();
+    ctx.fill();
   }
 
   /**

--- a/ui/src/plugins/lynx.nativemodule/types.ts
+++ b/ui/src/plugins/lynx.nativemodule/types.ts
@@ -23,6 +23,8 @@ export interface NativeModuleItem extends BaseSlice {
   depth: number;
   flowId: number;
   sections: NativeModuleSection[] | undefined;
+  invokeEndTs: number;
+  callbackStartTs: number;
 }
 
 export interface NativeModuleSection {

--- a/ui/src/plugins/lynx.scroll/index.ts
+++ b/ui/src/plugins/lynx.scroll/index.ts
@@ -36,9 +36,12 @@ import {LynxScrollTrack} from './track';
 import {getArgs} from '../../components/sql_utils/args';
 import {asArgSetId} from '../../components/sql_utils/core_types';
 import {ThreadSortOrder} from '../../lynx_perf/thread_order';
+import VitalTimestampPlugin from '../lynx.vitalTimestamp';
 
 export default class LynxScroll implements PerfettoPlugin {
   static readonly id = LYNX_SCROLL_PLUGIN_ID;
+
+  static readonly dependencies = [VitalTimestampPlugin];
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     const showTrack = await this.containValidScollSection(ctx);


### PR DESCRIPTION
Summary of changes:
- Display invoke chain of NativeModule using three main trace events: NativeModule::Invoke, NativeModule::Callback, NativeModule::PlatformCallbackStart
- On clicking a NativeModule item in the track, show related flow events
- Keep NativeModule item content always centered within its cell
- Add diagonal slash lines to indicate areas not executed on the Background Thread
