### PR TITLE
[BugFix] Improve validation logic for Special NativeModules

### DIFF
--- a/ui/src/plugins/lynx.nativemodule/tracks.ts
+++ b/ui/src/plugins/lynx.nativemodule/tracks.ts
@@ -342,32 +342,42 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
       if (it.name === NATIVEMODULE_INVOKE && it.key === 'debug.arg0') {
         const sliceName = it.stringValue || '';
         const startJSB = traceIdToJSBMap.get(it.id);
-        startJSB.firstArg = sliceName;
+        if (startJSB !== undefined) {
+          startJSB.firstArg = sliceName;
+        }
       } else if (
         it.name === NATIVEMODULE_NETWORK_REQUEST &&
         it.key === 'debug.url'
       ) {
         const startJSB = traceIdToJSBMap.get(it.id);
-        startJSB.url = it.stringValue;
-        startJSB.firstArg = 'NetworkRequest';
+        if (startJSB !== undefined) {
+          startJSB.url = it.stringValue;
+          startJSB.firstArg = 'NetworkRequest';
+        }
       } else if (it.name === NATIVEMODULE_INVOKE && it.key === 'debug.arg1') {
         const arg1 = stringToJsonObject(it.stringValue as string);
         if (arg1.data !== undefined && arg1.data.url !== undefined) {
           const startJSB = traceIdToJSBMap.get(it.id);
-          startJSB.url = arg1.data.url;
+          if (startJSB !== undefined) {
+            startJSB.url = arg1.data.url;
+          }
         }
       } else if (
         it.name === NATIVEMODULE_INVOKE &&
         it.key === 'debug.module_name'
       ) {
         const startJSB = traceIdToJSBMap.get(it.id);
-        startJSB.moduleName = it.stringValue;
+        if (startJSB !== undefined) {
+          startJSB.moduleName = it.stringValue;
+        }
       } else if (
         it.name === NATIVEMODULE_INVOKE &&
         it.key === 'debug.method_name'
       ) {
         const startJSB = traceIdToJSBMap.get(it.id);
-        startJSB.methodName = it.stringValue;
+        if (startJSB !== undefined) {
+          startJSB.methodName = it.stringValue;
+        }
       }
     }
     const sortedJsb = Array.from(traceIdToJSBMap.keys())


### PR DESCRIPTION
Previously, we identified special (synchronous) NativeModules by checking if their key flow traces occurred on non-background threads. However, this approach was not accurate and could lead to false positives. For example, due to incorrect thread assignment in trace events or bugs causing thread misclassification. We updated the validation logic to instead rely on the timing order of important flow traces:
1. For deprecated timing native module traces, the callback's end time must be after the platform method's end time.
2. For non-timing native module traces, the callback's end time must be after the native module invoke end time.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
