### PR TITLE
[BugFix] Resolve issue of selecting multiple pipeline traces when cli…

### DIFF
--- a/ui/src/core/flow_types.ts
+++ b/ui/src/core/flow_types.ts
@@ -51,6 +51,9 @@ export interface FlowPoint {
   // customise the name here, but for now we are hardcording a few
   // Chrome-specific bits in the query here.
   sliceChromeCustomName?: string;
+
+  pipelineIds?: string[];
+  pipelineId: string | null;
 }
 
 export type FlowDirection = 'Forward' | 'Backward';

--- a/ui/src/lynx_perf/flow_utils.ts
+++ b/ui/src/lynx_perf/flow_utils.ts
@@ -106,6 +106,7 @@ export async function querySliceRelatedFlows(
       depth: 0,
       threadName: nullToStr(it.beginThreadName),
       processName: 'NULL',
+      pipelineId: null,
     };
 
     const end = {
@@ -118,6 +119,7 @@ export async function querySliceRelatedFlows(
       depth: 0,
       threadName: nullToStr(it.endThreadName),
       processName: 'NULL',
+      pipelineId: null,
     };
 
     nodes.push(begin);

--- a/ui/src/lynx_perf/trace_utils.ts
+++ b/ui/src/lynx_perf/trace_utils.ts
@@ -19,6 +19,7 @@
 import {NUM, NUM_NULL} from '../trace_processor/query_result';
 import {Engine} from '../trace_processor/engine';
 import {BaseSlice} from './types';
+import {Flow} from '../core/flow_types';
 
 export async function findPrecedingIdenticalFlowIdSlice(
   engine: Engine,
@@ -92,4 +93,113 @@ export async function traceEventWithSpecificArgValue(
     where slice.name in (${traceNameList}) and slice.ts < ${endTs} and value='${argValue}' limit 1`,
   );
   return queryRes.numRows() > 0;
+}
+
+/**
+ * Thera are many pipelind_ids for 'LynxView.onDraw', we should filter the pipeline Flow which is
+ * not the same with 'Timing::Mark.paintEnd'
+ * @param engine
+ * @param flow
+ */
+export async function filterUncessaryPipleineFlow(
+  engine: Engine,
+  flow: Flow[],
+  pipelineId: string | null,
+) {
+  if (!pipelineId) {
+    return;
+  }
+  const filterPipelineIds: string[] = [];
+
+  flow.forEach((item) => {
+    item.begin.pipelineIds?.forEach((id) => {
+      if (id !== pipelineId && !filterPipelineIds.includes(id)) {
+        filterPipelineIds.push(id);
+      }
+    });
+    item.end.pipelineIds?.forEach((id) => {
+      if (id !== pipelineId && !filterPipelineIds.includes(id)) {
+        filterPipelineIds.push(id);
+      }
+    });
+  });
+  if (filterPipelineIds.length <= 0) {
+    return;
+  }
+  const flowNeedsToFilter: Flow[] = [];
+  flow.forEach((item) => {
+    if (filterPipelineIds.includes(item.begin.pipelineId || '')) {
+      flowNeedsToFilter.push(item);
+    }
+  });
+
+  const filterTraceIdList: number[] = [];
+  // find the trace which has the above filterPipelineIds
+  flow.forEach((item) => {
+    if (filterPipelineIds.includes(item.begin.pipelineId || '')) {
+      filterTraceIdList.push(item.begin.sliceId);
+    }
+  });
+  if (filterTraceIdList.length <= 0) {
+    return;
+  }
+  // find all the proceding flow for the above filterTraceIdList
+  const filterProcedingFlow: ProcedingFlow[] = [];
+  for (const id of filterTraceIdList) {
+    filterProcedingFlow.push(...(await queryProcedingFlows(engine, id)));
+  }
+
+  // remove the item in flow which satisfies the following condition:
+  // [item.begin.sliceid, item.end.sliceId] is in filterProcedingFlow
+  for (let i = flow.length - 1; i >= 0; i--) {
+    const item = flow[i];
+    if (
+      filterProcedingFlow.some(
+        (f) =>
+          f.beginSliceId === item.begin.sliceId &&
+          f.endSliceId === item.end.sliceId,
+      )
+    ) {
+      flow.splice(i, 1);
+    }
+  }
+
+  // remove the flow which has the pipelineId in filterPipelineIds
+  for (let i = flow.length - 1; i >= 0; i--) {
+    if (flowNeedsToFilter.includes(flow[i])) {
+      flow.splice(i, 1);
+    }
+  }
+}
+
+interface ProcedingFlow {
+  beginSliceId: number;
+  endSliceId: number;
+}
+
+export async function queryProcedingFlows(
+  engine: Engine,
+  sliceId: number,
+): Promise<ProcedingFlow[]> {
+  const query = `
+    -- Include slices.flow to initialise indexes on 'flow.slice_in' and 'flow.slice_out'.
+    INCLUDE PERFETTO MODULE slices.flow;
+    select
+      f.slice_out as beginSliceId,
+      f.slice_in as endSliceId
+      from preceding_flow(${sliceId}) f
+    `;
+  const result = await engine.query(query);
+  const it = result.iter({
+    beginSliceId: NUM,
+    endSliceId: NUM,
+  });
+  const flows: ProcedingFlow[] = [];
+  for (; it.valid(); it.next()) {
+    flows.push({
+      beginSliceId: it.beginSliceId,
+      endSliceId: it.endSliceId,
+    });
+  }
+  return flows;
 }


### PR DESCRIPTION
…cking on a pipeline bubble

Currently, when clicking on a pipeline bubble, it connects to `Lynx.onMeasure` via flowId. However, `Lynx.onMeasure` may be bound to multiple pipelineIds, which can result in connecting to traces corresponding to multiple previous pipelineIds. This update adds special handling when clicking on a pipelineId bubble to display only the trace points corresponding to that specific pipelineId.
