### PR TITLE
[BugFix] Ensure consistent instance_id across Trace events

### DIFF
--- a/src/trace_processor/importers/proto/track_event_parser.cc
+++ b/src/trace_processor/importers/proto/track_event_parser.cc
@@ -1409,8 +1409,10 @@ class TrackEventParser::EventImporter {
             args_writer.AddString(debug_key.key(), *flags);
           }
         }
-        if (!is_load_template_event && (annotation_name == "instance_id" ||
-                                        annotation_name == "instance_id_")) {
+        // Skip processing the empty name event such as counter event
+        if (!name.empty() && !is_load_template_event &&
+            (annotation_name == "instance_id" ||
+             annotation_name == "instance_id_")) {
           std::string id = "";
           if (annotation.has_string_value()) {
             id = annotation.string_value().ToStdString();


### PR DESCRIPTION
In some cases, Trace events were being assigned inconsistent instance_ids due to wrong row id asssignment when handling count-related events. This commit enhanced the execution condition inside the `SetInstanceIdForSlice` method (called within `AddExtraArgs`) to filter out scenarios where count events are involved.
