### PR TITLE
[Feature] Add one-click reset for LLM configuration

### DIFF
--- a/ui/src/components/lynx_perf/right_sidebar/ai_analysis/settings_button.tsx
+++ b/ui/src/components/lynx_perf/right_sidebar/ai_analysis/settings_button.tsx
@@ -52,6 +52,19 @@ export class SettingsButton extends Component<SettingsButtonProps, SettingsButto
     });
   };
 
+  resetSettings = () => {
+    this.setState({
+      llmConfig: {
+        baseUrl: '',
+        apiKey: '',
+        modelName: '',
+        modelProvider: '',
+        customPrompt: ''
+      }
+    });
+    message.success('Reset Settings Successfully');
+  };
+
   hideSettings = () => {
     this.setState({ showSettingsModal: false });
   };
@@ -108,6 +121,17 @@ export class SettingsButton extends Component<SettingsButtonProps, SettingsButto
           width={600}
           okText="Save"
           cancelText="Cancel"
+          footer={[
+            <Button key="reset" onClick={this.resetSettings}>
+              Reset
+            </Button>,
+            <Button key="cancel" onClick={this.hideSettings}>
+              Cancel
+            </Button>,
+            <Button key="save" type="primary" onClick={this.saveSettings}>
+              Save
+            </Button>,
+          ]}
         >
           <Form layout="vertical" style={{ marginTop: '16px' }}>
             <Form.Item label="Model Provider">


### PR DESCRIPTION
Added a "Reset" button on the LLM configuration page to allow users to clear all currently filled settings with a single click.

