### PR TITLE
[BugFix] Add tid to pipeline chart threads to fix chart event errors

### DIFF
--- a/ui/src/plugins/lynx.vitalTimestamp/details.tsx
+++ b/ui/src/plugins/lynx.vitalTimestamp/details.tsx
@@ -128,7 +128,7 @@ export class VitalTimestampDetailsPanel implements TrackEventDetailsPanel {
       slice.arg_set_id as argSetId,
       args.key as key,
       args.string_value as stringValue,
-      (IFNULL(thread.name, "Thread")) as threadName
+      (IFNULL(thread.name, "Thread") || ' ' || thread.tid) as threadName
       from slice 
       inner join args on args.arg_set_id = slice.arg_set_id
       left join thread_track on thread_track.id = slice.track_id


### PR DESCRIPTION
Different tracks may have identical thread names, causing events from separate tracks to be mistakenly merged into a single chart track. This update adds additional tid information to distinguish between different tracks.

