### PR TITLE
[Bugfix] Add null check for category in SliceTracker::MaybeCloseStack

### DIFF
--- a/src/trace_processor/importers/common/slice_tracker.cc
+++ b/src/trace_processor/importers/common/slice_tracker.cc
@@ -400,7 +400,7 @@ void SliceTracker::MaybeCloseStack(int64_t ts,
     auto category =
         context_->storage->GetString(ref.category().value_or(kNullStringId))
             .c_str();
-    if (strcmp(category, "jsprofile") == 0 && incomplete_descendent) {
+    if (category != nullptr && strcmp(category, "jsprofile") == 0 && incomplete_descendent) {
       ref.set_dur(ts - ref.ts());
       continue;
     }


### PR DESCRIPTION
Summary:
Fixed a potential null pointer issue in SliceTracker::MaybeCloseStack by checking if category is not nullptr before comparing its value. This prevents crashes when category is absent.
