### PR TITLE
[Optimize] Support filtering LynxView instances by instanceId parameter

### DIFF
--- a/ui/src/components/lynx_perf/right_sidebar/focus_lynxview_panel.tsx
+++ b/ui/src/components/lynx_perf/right_sidebar/focus_lynxview_panel.tsx
@@ -165,9 +165,14 @@ export class FocusLynxViewDetailPanel extends Component<{}, State> {
             onChange={this.handleChange}
             style={{width: '100%'}}
             defaultValue={this.state.value}
-            filterOption={(input, option) =>
-              (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
-            }
+            filterOption={(input, option) => {
+              const url = option?.label ?? '';
+              const instanceId = option?.value ?? '';
+              if (isFinite(Number(input))) {
+                return instanceId.startsWith(input);
+              }
+              return url.toLowerCase().includes(input.toLowerCase());
+            }}
             options={this.state.option}
             value={this.state.value}
             optionLabelProp="value"


### PR DESCRIPTION
Currently, only searching by URL is supported to find matching LynxView instances. When viewing the trace of a specific instanceId, it is inconvenient to obtain the URL information of the LynxView instance. Therefore, it is necessary to support searching and matching LynxView instances directly by instanceId.
