### PR TITLE
[BugFix] Improve link handling in AnalysisReportComponent

### DIFF
--- a/ui/src/components/lynx_perf/right_sidebar/ai_analysis/analysis_report.tsx
+++ b/ui/src/components/lynx_perf/right_sidebar/ai_analysis/analysis_report.tsx
@@ -120,14 +120,20 @@ export class AnalysisReportComponent extends Component<AnalysisReportProps> {
                     {children}
                   </h3>
                 ),
-                a: ({ href, children }: any) => (
-                  <a
-                    href={href}
-                    style={{ color: '#1890ff', textDecoration: 'underline' }}
-                  >
-                    {children}
-                  </a>
-                ),
+                a: ({ href, children }: any) => {
+                  const hasSliceId = href && this.getSliceIdFromUrl(href) !== null;
+                  
+                  return (
+                    <a
+                      href={href}
+                      style={{ color: '#1890ff', textDecoration: 'underline' }}
+                      target={hasSliceId ? undefined : '_blank'}
+                      rel={hasSliceId ? undefined : 'noopener noreferrer'}
+                    >
+                      {children}
+                    </a>
+                  );
+                },
               }}
             >
               {analysisResult}


### PR DESCRIPTION
Summary:
Updated the rendering logic for `<a>` tags in AnalysisReportComponent to conditionally set `target="_blank"` and `rel="noopener noreferrer"` only when the link does not contain a sliceId. This ensures external links open safely in a new tab, while internal sliceId links retain their default behavior.
