### PR TITLE
[BugFix] Fix missing flow lines rendering for some pipeline

### DIFF
--- a/ui/src/lynx_perf/constants.ts
+++ b/ui/src/lynx_perf/constants.ts
@@ -132,3 +132,9 @@ export const PIXEL_UPDATE = [
   'LynxBatchedUpdateData',
   'TemplateAssembler::CallLepusMethod',
 ];
+
+export const LYNX_VIEW_PLATFORM_RENDERING_METHOD = [
+  'LynxView.onMeasure',
+  'LynxView.onLayout',
+  'LynxView.onDraw',
+];

--- a/ui/src/lynx_perf/trace_utils.ts
+++ b/ui/src/lynx_perf/trace_utils.ts
@@ -20,6 +20,7 @@ import {NUM, NUM_NULL} from '../trace_processor/query_result';
 import {Engine} from '../trace_processor/engine';
 import {BaseSlice} from './types';
 import {Flow} from '../core/flow_types';
+import {LYNX_VIEW_PLATFORM_RENDERING_METHOD} from './constants';
 
 export async function findPrecedingIdenticalFlowIdSlice(
   engine: Engine,
@@ -144,29 +145,59 @@ export async function filterUncessaryPipleineFlow(
     return;
   }
   // find all the proceding flow for the above filterTraceIdList
-  const filterProcedingFlow: ProcedingFlow[] = [];
   for (const id of filterTraceIdList) {
-    filterProcedingFlow.push(...(await queryProcedingFlows(engine, id)));
-  }
+    const filterProcedingFlow = await queryProcedingFlows(engine, id);
 
-  // remove the item in flow which satisfies the following condition:
-  // [item.begin.sliceid, item.end.sliceId] is in filterProcedingFlow
-  for (let i = flow.length - 1; i >= 0; i--) {
-    const item = flow[i];
-    if (
-      filterProcedingFlow.some(
-        (f) =>
-          f.beginSliceId === item.begin.sliceId &&
-          f.endSliceId === item.end.sliceId,
-      )
-    ) {
-      flow.splice(i, 1);
+    // remove the item in flow which satisfies the following condition:
+    // [item.begin.sliceid, item.end.sliceId] is in filterProcedingFlow
+    for (let i = flow.length - 1; i >= 0; i--) {
+      const item = flow[i];
+      // Special case handling: If the current rendering method is LynxView platform layer, and the
+      // number of pipelineIds is no more than 1, it indicates that there was no selection of multiple
+      // pipelines prior to this point, and the process of removing the flow should be skipped.
+      if (
+        LYNX_VIEW_PLATFORM_RENDERING_METHOD.includes(item.begin.sliceName) &&
+        (!item.begin.pipelineIds || item.begin.pipelineIds.length <= 1)
+      ) {
+        break;
+      }
+      if (
+        LYNX_VIEW_PLATFORM_RENDERING_METHOD.includes(item.end.sliceName) &&
+        (!item.end.pipelineIds || item.end.pipelineIds.length <= 1)
+      ) {
+        break;
+      }
+      if (
+        filterProcedingFlow.some(
+          (f) =>
+            f.beginSliceId === item.begin.sliceId &&
+            f.endSliceId === item.end.sliceId,
+        )
+      ) {
+        flow.splice(i, 1);
+      }
     }
   }
 
   // remove the flow which has the pipelineId in filterPipelineIds
   for (let i = flow.length - 1; i >= 0; i--) {
-    if (flowNeedsToFilter.includes(flow[i])) {
+    const item = flow[i];
+    // Special case handling: If the current rendering method is LynxView platform layer, and the
+    // number of pipelineIds is no more than 1, it indicates that there was no selection of multiple
+    // pipelines prior to this point, and the process of removing the flow should be skipped.
+    if (
+      LYNX_VIEW_PLATFORM_RENDERING_METHOD.includes(item.begin.sliceName) &&
+      (!item.begin.pipelineIds || item.begin.pipelineIds.length <= 1)
+    ) {
+      continue;
+    }
+    if (
+      LYNX_VIEW_PLATFORM_RENDERING_METHOD.includes(item.end.sliceName) &&
+      (!item.end.pipelineIds || item.end.pipelineIds.length <= 1)
+    ) {
+      continue;
+    }
+    if (flowNeedsToFilter.includes(item)) {
       flow.splice(i, 1);
     }
   }


### PR DESCRIPTION
Problem:
- In LynxView.onDraw phase with multiple paintEnd pipelines, LynxView.onLayout phase removes all preceding flow lines for non-selected pipelines during list item rendering
- This incorrectly removes shared flow lines between list items and preceding UpdateData (which have identical preceding flow lines)

Solution:
- Add special handling by checking pipelineIds count
- Only remove preceding flow lines when pipelineIds contains exactly 1 pipeline- Prevents erroneous removal of shared flow lines in multi-pipeline scenarios
