### PR TITLE
[Optimize] Skip Lynx version check in AI Analysis if Lynx version inf…

### DIFF
--- a/ui/src/components/lynx_perf/right_sidebar/assistant_panel.tsx
+++ b/ui/src/components/lynx_perf/right_sidebar/assistant_panel.tsx
@@ -262,7 +262,7 @@ export class TraceAssistantPanel extends Component<{}, TraceAssistantPanelState>
     }
     const result = await engine.query(`select args.display_value from slice join args on args.arg_set_id=slice.arg_set_id where slice.name='LynxEngineVersion' and args.key='debug.version'`);
     const version = result.numRows() > 0 ? result.firstRow({display_value: STR}).display_value : '';
-    return version >= '3.4';
+    return !version || version >= '3.4';
   };
 
   validateLLMConfig = (): boolean => {

--- a/ui/src/plugins/lynx.vitalTimestamp/details.tsx
+++ b/ui/src/plugins/lynx.vitalTimestamp/details.tsx
@@ -36,6 +36,7 @@ import {getSlice, SliceDetails} from '../../components/sql_utils/slice';
 import {asArgSetId, asSliceSqlId} from '../../components/sql_utils/core_types';
 import {Arg, getArgs} from '../../components/sql_utils/args';
 import {eventLoggerState} from '../../event_logger';
+import {stringToJsonObject} from '../../lynx_perf/string_utils';
 
 /**
  * Pipeline Stage Interface
@@ -342,7 +343,10 @@ export class VitalTimestampDetailsPanel implements TrackEventDetailsPanel {
     if (!jsonTree) {
       return undefined;
     }
-    const rootElementAbbr = JSON.parse(jsonTree);
+    const rootElementAbbr = stringToJsonObject(jsonTree);
+    if (rootElementAbbr === undefined) {
+      return undefined;
+    }
     return reConstructElementTree(rootElementAbbr, undefined);
   }
 


### PR DESCRIPTION
…o is missing in trace

- Skip Lynx version validation when trace lacks version info to improve robustness
- Replace JSON.parse with stringToJsonObject to prevent potential crashes during parsing

