### PR TITLE
[BugFix] Advance the initialization timing of process_uuid to resolve…

### DIFF
--- a/sdk/perfetto.cc
+++ b/sdk/perfetto.cc
@@ -43101,7 +43101,7 @@ TracingPolicy::~TracingPolicy() = default;
 namespace perfetto {
 
 // static
-uint64_t Track::process_uuid;
+uint64_t Track::process_uuid = internal::TrackRegistry::ComputeProcessUuid();
 
 protos::gen::TrackDescriptor Track::Serialize() const {
   protos::gen::TrackDescriptor desc;
@@ -43275,7 +43275,6 @@ void TrackRegistry::InitializeInstance() {
   if (instance_)
     return;
   instance_ = new TrackRegistry();
-  Track::process_uuid = ComputeProcessUuid();
 }
 
 // static

--- a/src/tracing/track.cc
+++ b/src/tracing/track.cc
@@ -34,7 +34,7 @@
 namespace perfetto {
 
 // static
-uint64_t Track::process_uuid;
+uint64_t Track::process_uuid = internal::TrackRegistry::ComputeProcessUuid();
 
 protos::gen::TrackDescriptor Track::Serialize() const {
   protos::gen::TrackDescriptor desc;
@@ -208,7 +208,6 @@ void TrackRegistry::InitializeInstance() {
   if (instance_)
     return;
   instance_ = new TrackRegistry();
-  Track::process_uuid = ComputeProcessUuid();
 }
 
 // static


### PR DESCRIPTION
… the inconsistency issue before and after initialization.

When TrackRegistry::InitializeInstance() has not been executed, process_uuid is 0; after execution it becomes a normal value. Because the value differs before and after, in Lynx, if the JS runtime profile initializes before the trace controller, it receives a process_uuid of 0, causing the final Track to be separated from the thread it actually belongs to.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
