### PR TITLE
feat: add pending start analysis flag for AI analysis prompt

### DIFF
--- a/ui/src/components/lynx_perf/right_sidebar/assistant_panel.tsx
+++ b/ui/src/components/lynx_perf/right_sidebar/assistant_panel.tsx
@@ -84,6 +84,11 @@ export class TraceAssistantPanel extends Component<{}, TraceAssistantPanelState>
           extraActionArea: extraActionArea,
           extraActionProperties: prevAnalysisResult.extraActionProperties,
         });
+      } else if (this.state.status === 'initial' && llmState.state.pendingStartAnalysis) {
+        llmState.edit((draft) => {
+          draft.pendingStartAnalysis = false;
+        });
+        this.startAnalysis();
       }
     } catch (error) {
       console.error('restore prev report status failed : ', error);

--- a/ui/src/lynx_perf/llm_state.ts
+++ b/ui/src/lynx_perf/llm_state.ts
@@ -61,6 +61,7 @@ interface State {
   modelChoosePanel: React.ReactNode | undefined;
   reportExtraAction: ReportExtraAction | undefined;
   traceAnalysis: TraceAnalysis | undefined;
+  pendingStartAnalysis: boolean;
 }
 
 const emptyState: State = {
@@ -75,6 +76,7 @@ const emptyState: State = {
   modelChoosePanel: undefined,
   reportExtraAction: undefined,
   traceAnalysis: undefined,
+  pendingStartAnalysis: false,
 };
 
 export const llmState = createStore<State>(emptyState);


### PR DESCRIPTION
Add a pendingStartAnalysis flag to llm_state to handle the timing issue when the AI analysis prompt modal triggers analysis before the TraceAssistantPanel is mounted. The panel now checks this flag on mount and starts analysis automatically if it was set by the prompt modal.
