### PR TITLE
[Infra][SDK] Add perfetto GN build target

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright 2024 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+perfetto_header_files = [ "perfetto.h" ]
+
+perfetto_shared_sources = [ "perfetto.cc" ]
+
+config("allow_sign_compare") {
+  cflags = [ "-Wno-sign-compare" ]
+}
+
+source_set("perfetto") {
+  sources = perfetto_shared_sources + perfetto_header_files
+
+  # On some platfoms, cmsg = CMSG_NXTHDR(&msg_hdr, cmsg)) will cause build break:
+  #  comparison of integers of different signs: 'unsigned long' and 'long'
+  configs += [ ":allow_sign_compare" ]
+}


### PR DESCRIPTION
Introduce `sdk/BUILD.gn` defining a `perfetto` source_set with `perfetto.h` and `perfetto.cc`, and apply a build config to suppress signed/unsigned comparison warnings that can break builds on some platforms. Also declare `//third_party/zlib` as a dependency.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
