### PR TITLE
chore: update CODEOWNERS for internal team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,38 +1,13 @@
 # This file define code owners for GitHub pull requests
 # NOTE: The last matching rule is the one that defines the owner.
 
-# General repo-wide owners 
-* @google/perfetto-team
-
-# ui.perfetto.dev
-/ui/**/* @google/perfetto-ui-team
-
-# On-device and SDK code
-/src/**/* @google/perfetto-traced-team
-/include/**/* @google/perfetto-traced-team
-
-# Trace Processor (keep after src/*)
-/src/trace_processor/**/* @google/perfetto-tp-team
-/include/perfetto/ext/trace_processor/**/* @google/perfetto-tp-team
-/include/perfetto/trace_processor/**/* @google/perfetto-tp-team
+* @KananSu @KingAlen @lynx-family
 
 # Files/Directories that don't require a strict owner check.
 /Android.bp
 /Android.bp.extras
 /BUILD
 /BUILD.*
-/docs/**/*
 /examples/**/*
-/protos/perfetto/trace/**/*
-/protos/perfetto/config/**/*
-/protos/perfetto/metrics/**/*
-/ui/src/plugins/**/*
 /ui/src/test/**/*
-/tools/**/*
 /test/**/*
-
-# Changes to the Tracing Protocol ABI are extremely subtle because they need to
-# be forward/backward compatible with various combinations of producer and
-# service versions. Adding >1 owner to reviews is encouraged here.
-# TODO(primiano): add @betasheet once he joins google org
-/protos/perfetto/ipc/**/* @primiano @LalitMaganti


### PR DESCRIPTION
Replace upstream teams with lynx maintainers to ensure correct PR reviewer assignments in the forked repository. Ownership hierarchy applied based on the last matching rule
