### PR TITLE
Only add debug info for debug builds

### DIFF
--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -242,10 +242,13 @@ config("default") {
     }
   } else if (!is_wasm) {  # !is_win
     cflags += [
-      "-g",
       "-fPIC",
       "-fstack-protector-strong",
     ]
+    # Only add debug info for debug builds
+    if (is_debug) {
+      cflags += [ "-g" ]
+    }
   }
 
   # Treat warnings as errors, but give up on fuzzer builds.


### PR DESCRIPTION
Only add -g flag when is_debug is true, which reduces the binary size for release builds significantly without needing to strip debug info post-compilation.

This also avoids cross-architecture stripping issues when building linux binaries.
