### PR TITLE
feat: refactor query functions error handling in external_repo

### DIFF
--- a/trace_analysis/packages/agent/src/tools/trace_query/query_aggregate.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_aggregate.ts
@@ -11,20 +11,20 @@ export const aggregateQueryTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
-      const result = await queryAggregate(traceQuery, start_ts_ms, end_ts_ms, names || [], track_id);
+      const result = await queryAggregate(traceQuery, start_ts_ms, end_ts_ms, names, track_id);
       result.sort((a, b) => b.total_duration_ms - a.total_duration_ms);
       return JSON.stringify(result.slice(0, 200));
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {
@@ -36,7 +36,6 @@ export const aggregateQueryTool = tool(
       end_ts_ms: z.number().describe('End timestamp in milliseconds.'),
       names: z
         .array(z.string())
-        .optional()
         .describe(
           'Event name patterns to match. Supports SQL LIKE wildcards: % matches any sequence of characters, _ matches any single character. Example: ["Timing::Mark%", "Lynx%"]',
         ),

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_ancestors.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_ancestors.ts
@@ -15,18 +15,18 @@ export const queryAncestorsTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const event = await queryById(traceQuery, slice_id);
       if (!event || event.length === 0 || !event[0]) {
-        return JSON.stringify({ error: 'slice_id not found' });
+        return JSON.stringify({ errorMessage: 'slice_id not found' });
       }
       const start_ts = event[0].ts / NS_TO_MS;
       const end_ts = (event[0].ts + event[0].dur) / NS_TO_MS;
@@ -35,7 +35,7 @@ export const queryAncestorsTool = tool(
       const event_tree = getTreeStyleTraceEvents(simplifiedResult);
       return JSON.stringify(event_tree);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_by_id.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_by_id.ts
@@ -11,23 +11,23 @@ export const queryByIdTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryById(traceQuery, slice_id);
       if (!result || result.length === 0) {
-        return JSON.stringify({ error: 'slice_id not found' });
+        return JSON.stringify({ errorMessage: 'slice_id not found' });
       }
       const event_tree = getTreeStyleTraceEvents(result);
       return JSON.stringify(event_tree);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_by_raw_sql.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_by_raw_sql.ts
@@ -11,19 +11,19 @@ export const queryByRawSqlTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryByRawSql(traceQuery, sql);
       return JSON.stringify(result);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_by_time_window.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_by_time_window.ts
@@ -13,21 +13,21 @@ export const queryByTimeWindowTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryByTimeWindow(traceQuery, start_ts_ms, end_ts_ms, track_id);
       const simplifiedResult = await simplifyQueryResult(result, start_ts_ms, end_ts_ms);
       const event_tree = getTreeStyleTraceEvents(simplifiedResult);
       return JSON.stringify(event_tree);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_descendants.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_descendants.ts
@@ -15,18 +15,18 @@ export const queryDescendantsTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const event = await queryById(traceQuery, slice_id);
       if (!event || event.length === 0 || !event[0]) {
-        return JSON.stringify({ error: 'slice_id not found' });
+        return JSON.stringify({ errorMessage: 'slice_id not found' });
       }
       const start_ts = event[0].ts / NS_TO_MS;
       const end_ts = (event[0].ts + event[0].dur) / NS_TO_MS;
@@ -35,7 +35,7 @@ export const queryDescendantsTool = tool(
       const event_tree = getTreeStyleTraceEvents(simplifiedResult);
       return JSON.stringify(event_tree);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_flow_events.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_flow_events.ts
@@ -13,21 +13,21 @@ export const queryFlowEventsTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryFlowEvents(traceQuery, slice_id);
       const simplifiedResult = await simplifyQueryResult(result);
       const event_tree = getTreeStyleTraceEvents(simplifiedResult);
       return JSON.stringify(event_tree);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_long_task.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_long_task.ts
@@ -15,14 +15,14 @@ export const queryLongTasksTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryLongTasks(traceQuery, track_id, min_duration_ms);
       if (result.length > 0) {
@@ -34,10 +34,10 @@ export const queryLongTasksTool = tool(
         const event_tree = getTreeStyleTraceEvents(simplifiedResult);
         return JSON.stringify(event_tree);
       } else {
-        return JSON.stringify({ error: 'No long tasks found' });
+        return JSON.stringify({ errorMessage: 'No long tasks found' });
       }
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_lynxviews.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_lynxviews.ts
@@ -11,19 +11,19 @@ export const queryLynxViewTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryLynxView(traceQuery);
       return JSON.stringify(result);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_metrics.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_metrics.ts
@@ -11,19 +11,19 @@ export const queryMetricsTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryMetrics(traceQuery);
       return JSON.stringify(result);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_pipeline_ids.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_pipeline_ids.ts
@@ -11,19 +11,19 @@ export const queryPipelineIdsTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryPipelineIds(traceQuery, instance_id);
       return JSON.stringify(result);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_pipeline_overview_events.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_pipeline_overview_events.ts
@@ -11,19 +11,19 @@ export const queryPipelineOverviewEventsTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryPipelineOverviewEvents(traceQuery, pipeline_id, keep_non_top_update_event === true);
       return JSON.stringify(result);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_threads.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_threads.ts
@@ -11,19 +11,19 @@ export const queryThreadsTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryThreads(traceQuery, lynxThreadOnly);
       return JSON.stringify(result);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/trace_analysis/packages/agent/src/tools/trace_query/query_trace_metadata.ts
+++ b/trace_analysis/packages/agent/src/tools/trace_query/query_trace_metadata.ts
@@ -11,19 +11,19 @@ export const queryTraceMetadataTool = tool(
     try {
       const traceQuerys = config.configurable?.traceQuerys as TraceQuery[];
       if (!traceQuerys || traceQuerys.length === 0) {
-        throw new Error('TraceQuerys not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuerys not found in config' });
       }
       if (index < 0 || index >= traceQuerys.length) {
-        throw new Error('Invalid trace index');
+        return JSON.stringify({ errorMessage: 'Invalid trace index' });
       }
       const traceQuery = traceQuerys[index];
       if (!traceQuery) {
-        throw new Error('TraceQuery not found in config');
+        return JSON.stringify({ errorMessage: 'TraceQuery not found in config' });
       }
       const result = await queryTraceMetadata(traceQuery);
       return JSON.stringify(result);
     } catch (error) {
-      throw new Error((error as Error).message);
+      return JSON.stringify({ errorMessage: (error as Error).message });
     }
   },
   {

--- a/ui/src/components/lynx_perf/right_sidebar/assistant_panel.tsx
+++ b/ui/src/components/lynx_perf/right_sidebar/assistant_panel.tsx
@@ -7,11 +7,9 @@ import { Button } from 'antd';
 import { AnalysisProcess } from './ai_analysis/analysis_process';
 import { AnalysisReportComponent } from './ai_analysis/analysis_report';
 import { SettingsButton } from './ai_analysis/settings_button';
-import { AppImpl } from '../../../core/app_impl';
 import AIAnalysis from '../../../plugins/lynx.AIAnalysis';
 import { AnalysisReport, AnalysisStep, llmState, StepListener, EventData } from '../../../lynx_perf/llm_state';
 import { updateAnalysisSteps, convertEventDataArrayToAnalysisSteps } from '../../../lynx_perf/analysis_step_utils';
-import { STR } from '../../../trace_processor/query_result';
 import { eventLoggerState } from '../../../event_logger';
 
 
@@ -47,16 +45,6 @@ export class TraceAssistantPanel extends Component<{}, TraceAssistantPanelState>
   }
 
   performValidation = async () => {
-    const isLynxVersionValid = await this.validateLynxVersion();
-    if (!isLynxVersionValid) {
-      this.setState({
-        validationError: 'Use Lynx SDK version 3.4 or above to enable AI analysis.',
-        isValidationPassed: false
-      });
-      eventLoggerState.state.eventLogger.logEvent('ai_analysis_low_lynx_version', {});
-      return;
-    }
-
     const isLLMConfigValid = this.validateLLMConfig();
     if (!isLLMConfigValid) {
       this.setState({
@@ -191,16 +179,6 @@ export class TraceAssistantPanel extends Component<{}, TraceAssistantPanelState>
       });
     }
   }
-
-  validateLynxVersion = async (): Promise<boolean> => {
-    const engine = AppImpl.instance.trace?.engine;
-    if (!engine) {
-      return true;
-    }
-    const result = await engine.query(`select args.display_value from slice join args on args.arg_set_id=slice.arg_set_id where slice.name='LynxEngineVersion' and args.key='debug.version'`);
-    const version = result.numRows() > 0 ? result.firstRow({ display_value: STR }).display_value : '';
-    return !version || version >= '3.4';
-  };
 
   validateLLMConfig = (): boolean => {
     const config = this.getLLMConfig();


### PR DESCRIPTION
- Modify all queryXXXX functions in trace_query to return errorMessage instead of throwing exceptions
- Update catch blocks to return JSON.stringify({ errorMessage: ... }) instead of rethrowing errors
- Remove Lynx SDK version validation from AI analysis panel
