### PR TITLE
docs: clarify that protos.js is auto-generated in http.ts

### DIFF
--- a/trace_analysis/packages/trace_query/src/trace_processor/http.ts
+++ b/trace_analysis/packages/trace_query/src/trace_processor/http.ts
@@ -6,6 +6,8 @@ import * as fs from 'fs';
 
 import fetch from 'node-fetch';
 
+// protos.js and protos.d.ts are auto-generated files by compile_proto.mjs during build
+// @ts-expect-error
 import protos from './protos.js';
 
 export interface TraceReference {


### PR DESCRIPTION
- Add comment indicating protos.js and protos.d.ts are generated by compile_proto.mjs