### PR TITLE
fix: add @lynx-js/skill-lynx-trace-analysis to workspace for release

### DIFF
--- a/trace_analysis/packages/trace_record/package.json
+++ b/trace_analysis/packages/trace_record/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@byted-lynx/trace-record",
+  "name": "@lynx-js/trace-record",
   "version": "0.0.1",
+  "private": true,
   "description": "Lynx trace record library and CLI tool",
   "keywords": [
     "lynx",

--- a/trace_analysis/pnpm-workspace.yaml
+++ b/trace_analysis/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'packages/*'
+  - 'skills'

--- a/trace_analysis/skills/package.json
+++ b/trace_analysis/skills/package.json
@@ -10,11 +10,20 @@
     "reference.md",
     "examples.md"
   ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-trace.git",
+    "directory": "trace_analysis/skills"
+  },
   "scripts": {
   },
   "devDependencies": {
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
- Add skills directory to pnpm-workspace.yaml
- Add publishConfig to @lynx-js/skill-lynx-trace-analysis package
- Mark @lynx-js/trace-record as private and rename for internal use only
- Include @lynx-js/skill-lynx-trace-analysis in release workflow
