### PR TITLE
ci: update release.yml to use Node.js 24 and latest actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -24,20 +27,20 @@ jobs:
       run:
         working-directory: ./trace_analysis
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Upgrade npm CLI to latest
         run: npm install -g npm@latest
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.26.1
 


### PR DESCRIPTION
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 environment variable
- Upgrade actions/checkout from v4 to v6
- Upgrade actions/setup-node from v4 to v6
- Upgrade pnpm/action-setup from v4 to v5
- Update Node.js version from 20 to 24
