### PR TITLE
fix(trace_query): fix main thread detection in queryThreads

### DIFF
--- a/trace_analysis/packages/trace_query/src/queries/query_threads.ts
+++ b/trace_analysis/packages/trace_query/src/queries/query_threads.ts
@@ -12,27 +12,44 @@ export interface ThreadInfo {
 }
 
 export async function queryThreads(traceQuery: TraceQuery, lynxThreadOnly: boolean = true): Promise<ThreadInfo[]> {
-  const sql = `
-    SELECT tt.id, t.tid, t.name
+  const sql = `SELECT
+    tt.id,
+    t.tid,
+    t.name,
+    CASE
+      WHEN EXISTS (
+          SELECT 1
+          FROM process p
+          WHERE p.pid = t.tid
+            AND p.pid <> 0
+      ) THEN 1
+      ELSE 0
+    END AS isMainThread
     FROM thread t
-    LEFT JOIN thread_track tt ON t.utid = tt.utid
-    WHERE t.utid != 0 and tt.id is not NULL
-    ORDER BY t.tid
+    INNER JOIN thread_track tt ON t.utid = tt.utid
+    WHERE t.utid <> 0
+    ORDER BY t.tid;
   `;
 
   let result = await traceQuery.query(sql);
   if (result.length === 0 || result[0] === undefined) {
     return [];
   }
-  const mainThread = result[0];
-  if (lynxThreadOnly) {
-    result = result.filter((row: any) => row.name && (row.name.startsWith('lynx') || row.name.startsWith('Lynx')));
+
+  const mainThread = result.find((row: any) => row.isMainThread === 1);
+  // If no main thread is found, set the first thread as the main thread.
+  if (!mainThread) {
+    result[0]['isMainThread'] = 1;
   }
-  result.push(mainThread);
+  if (lynxThreadOnly) {
+    result = result.filter(
+      (row: any) => row.name && (row.name.startsWith('lynx') || row.name.startsWith('Lynx') || row.isMainThread === 1),
+    );
+  }
   return result.map((row: any) => ({
     track_id: row.id,
     tid: row.tid,
     name: row.name || `Thread ${row.tid}`,
-    isMainThread: row.id === mainThread['id'],
+    isMainThread: row.isMainThread === 1,
   }));
 }


### PR DESCRIPTION
- Improve main thread identification using process table lookup
- Avoid assuming first thread is always main thread
