### PR TITLE
fix(trace-record): change js-profile-type default from sampling to quickjs

### DIFF
--- a/trace_analysis/packages/trace_record/src/cli/index.ts
+++ b/trace_analysis/packages/trace_record/src/cli/index.ts
@@ -78,7 +78,7 @@ interface CommandOptions {
   client: string;
   enableSystrace?: boolean;
   jsProfileInterval?: string;
-  jsProfileType?: string;
+  jsProfileType?: 'quickjs' | 'v8';
   stream?: string;
   output?: string;
 }
@@ -129,7 +129,7 @@ async function main() {
     .requiredOption('-c, --client <clientId>', 'Client ID')
     .option('--enable-systrace', 'Enable systrace', true)
     .option('--js-profile-interval <interval>', 'JS profile interval', '-1')
-    .option('--js-profile-type <type>', 'JS profile type', 'sampling')
+    .option('--js-profile-type <type>', 'JS profile type (quickjs or v8)', 'quickjs')
     .action(async (options: CommandOptions) => {
       const connector = new DevtoolConnector(transports);
       const clientId = options.client;

--- a/trace_analysis/skills/trace-record-skill/scripts/trace_record.bundle.cjs
+++ b/trace_analysis/skills/trace-record-skill/scripts/trace_record.bundle.cjs
@@ -290,7 +290,7 @@ async function main() {
         .requiredOption('-c, --client <clientId>', 'Client ID')
         .option('--enable-systrace', 'Enable systrace', true)
         .option('--js-profile-interval <interval>', 'JS profile interval', '-1')
-        .option('--js-profile-type <type>', 'JS profile type', 'sampling')
+        .option('--js-profile-type <type>', 'JS profile type (quickjs or v8)', 'quickjs')
         .action(async (options) => {
         const connector = new _lynx_js_devtool_connector__WEBPACK_IMPORTED_MODULE_5__/* .Connector */ .Wi(transports);
         const clientId = options.client;


### PR DESCRIPTION
- Update --js-profile-type option to only accept 'quickjs' or 'v8' values instead of the previous 'sampling' default, which was not a valid option.
