### PR TITLE
feat(trace_query): add fuzzy search capability for trace events

### DIFF
--- a/trace_analysis/docs/templates/skill_template.md
+++ b/trace_analysis/docs/templates/skill_template.md
@@ -17,6 +17,7 @@ The tools in this Skill can be invoked via the following CLI commands without ad
 | Command | Description |
 |---------|-------------|
 | `id` | Execute trace query by slice ID |
+| `search` | Fuzzy-search trace events whose slice name or args contain the given text |
 | `time-window` | Execute time window query |
 | `aggregate` | Execute aggregate query |
 | `ancestors` | Query ancestors of a slice |
@@ -47,6 +48,12 @@ The tools in this Skill can be invoked via the following CLI commands without ad
 
   ```bash
   $ node <path_to_the_skill>/scripts/trace_query.bundle.cjs id --id 381 --path "https://example.com/trace.pftrace"
+  ```
+
+- **Fuzzy-search trace events:**
+
+  ```bash
+  $ node <path_to_the_skill>/scripts/trace_query.bundle.cjs search --text 'loadBackground' --path "https://example.com/trace.pftrace"
   ```
 
 - **Query by time window:**

--- a/trace_analysis/packages/trace_query/README.md
+++ b/trace_analysis/packages/trace_query/README.md
@@ -13,13 +13,17 @@ pnpm add @lynx-js/trace-query
 ### Programmatic
 
 ```typescript
-import { TraceQuery, queryById, queryByTimeWindow } from '@lynx-js/trace-query';
+import { TraceQuery, queryById, queryBySearchText, queryByTimeWindow } from '@lynx-js/trace-query';
 
 const traceQuery = new TraceQuery();
 await traceQuery.initProcessor('/path/to/trace.pftrace');
 
 // Query by ID
 const slice = await queryById(traceQuery, 123);
+
+// Search slices by text across slice names, arg keys, and arg values.
+// Numeric text also matches the exact slice ID.
+const matches = await queryBySearchText(traceQuery, 'Card');
 
 // Query by time window
 const slices = await queryByTimeWindow(traceQuery, 1000, 2000);
@@ -35,6 +39,9 @@ node dist/cli/index.js --help
 
 # Query by slice ID
 node dist/cli/index.js id --id 381 --path "https://example.com/trace.pftrace"
+
+# Search slices by text
+node dist/cli/index.js search --text "Card" --path "/path/to/trace.pftrace"
 
 # Query by time window
 node dist/cli/index.js time-window --start 1000 --end 2000 --path "/path/to/trace.pftrace"
@@ -60,6 +67,7 @@ node dist/cli/index.js long-tasks --track 6 --duration 16 --path "/path/to/trace
 | Command | Description |
 |---------|-------------|
 | `id` | Query slice by ID |
+| `search` | Fuzzy-search trace events whose slice name or args contain the given text |
 | `time-window` | Query slices within a time range |
 | `aggregate` | Aggregate events by name |
 | `ancestors` | Query ancestor slices |
@@ -81,6 +89,7 @@ All commands require `-p, --path <path>` to specify the trace file (URL or local
 | Method | Description |
 |--------|-------------|
 | `queryById` | Query a slice by its ID |
+| `queryBySearchText` | Search slices by text across names, args, and exact numeric IDs |
 | `queryByTimeWindow` | Query slices within a time window |
 | `queryAggregate` | Aggregate events by name pattern |
 | `queryAncestors` | Get ancestor slices |

--- a/trace_analysis/packages/trace_query/src/cli/index.ts
+++ b/trace_analysis/packages/trace_query/src/cli/index.ts
@@ -8,6 +8,7 @@ import { queryAggregate } from '../queries/query_aggregate';
 import { queryAncestors } from '../queries/query_ancestors';
 import { queryById } from '../queries/query_by_id';
 import { queryByRawSql } from '../queries/query_by_raw_sql';
+import { queryBySearchText } from '../queries/query_by_search_text';
 import { queryByTimeWindow } from '../queries/query_by_time_window';
 import { queryDescendants } from '../queries/query_descendants';
 import { queryFlowEvents } from '../queries/query_flow_events';
@@ -25,6 +26,7 @@ import { TraceQuery } from '../utils/trace_query';
 interface CommandOptions {
   path?: string;
   id?: string;
+  text?: string;
   start?: string;
   end?: string;
   track?: string;
@@ -139,6 +141,26 @@ async function main() {
 
         console.log('Query result:', JSON.stringify(result, null, 2));
       }),
+    );
+
+  program
+    .command('search')
+    .description('Search trace events by text')
+    .option('--text <text>', 'Search text')
+    .option('-p, --path <path>', 'Trace file path (can be URL or local file)')
+    .action(
+      wrapCommandAction(
+        'search',
+        async (options: CommandOptions, traceQuery: TraceQuery) => {
+          requireOption(options.path, 'path');
+          const text = requireOption(options.text, 'text');
+
+          const events = await queryBySearchText(traceQuery, text);
+          const result = getTreeStyleTraceEvents(events);
+
+          console.log('Search result:', JSON.stringify(result, null, 2));
+        },
+      ),
     );
 
   program

--- a/trace_analysis/packages/trace_query/src/queries/index.ts
+++ b/trace_analysis/packages/trace_query/src/queries/index.ts
@@ -6,6 +6,7 @@ export * from './query_ancestors';
 export * from './query_by_id';
 export * from './query_aggregate';
 export * from './query_by_raw_sql';
+export * from './query_by_search_text';
 export * from './query_by_time_window';
 export * from './query_descendants';
 export * from './query_flow_events';

--- a/trace_analysis/packages/trace_query/src/queries/query_by_search_text.ts
+++ b/trace_analysis/packages/trace_query/src/queries/query_by_search_text.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { TraceEvent } from '../types/trace_event';
+import { parseTraceEvent } from '../utils/parse_trace_event';
+import { TraceQuery } from '../utils/trace_query';
+
+function escapeSqlLiteral(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+function escapeGlobPattern(value: string): string {
+  return value.replace(/([*?\[])/g, '[$1]');
+}
+
+export async function queryBySearchText(traceQuery: TraceQuery, searchText: string): Promise<TraceEvent[]> {
+  const trimmedSearchText = searchText.trim();
+
+  if (!trimmedSearchText) {
+    return [];
+  }
+
+  const normalizedSearchText = trimmedSearchText.toLowerCase();
+  const globPattern = `*${escapeSqlLiteral(escapeGlobPattern(normalizedSearchText))}*`;
+
+  const sql =
+    'WITH matched_slices AS ( ' +
+    'SELECT s.id ' +
+    'FROM slice s ' +
+    'LEFT JOIN args a ON s.arg_set_id = a.arg_set_id ' +
+    `WHERE lower(s.name) GLOB '${globPattern}' OR lower(a.string_value) GLOB '${globPattern}' OR lower(a.display_value) GLOB '${globPattern}' OR lower(a.key) GLOB '${globPattern}' ` +
+    'GROUP BY s.id ' +
+    ') ' +
+    'SELECT s.id, s.track_id, s.ts, s.dur, s.name, s.depth, t.name as thread_name, json_group_object(a.key, a.display_value) AS args ' +
+    'FROM matched_slices ms ' +
+    'JOIN slice s ON ms.id = s.id ' +
+    'LEFT JOIN args a ON s.arg_set_id = a.arg_set_id ' +
+    'JOIN thread_track tt ON s.track_id = tt.id ' +
+    'JOIN thread t ON tt.utid = t.utid ' +
+    'GROUP BY s.id, s.track_id, s.ts, s.dur, s.name, s.depth, t.name ' +
+    'ORDER BY s.ts';
+
+  const queryResult = await traceQuery.query(sql);
+  return parseTraceEvent(queryResult);
+}

--- a/trace_analysis/skills/trace-analysis-skill/SKILL.md
+++ b/trace_analysis/skills/trace-analysis-skill/SKILL.md
@@ -110,6 +110,7 @@ The tools in this Skill can be invoked via the following CLI commands without ad
 | Command | Description |
 |---------|-------------|
 | `id` | Execute trace query by slice ID |
+| `search` | Fuzzy-search trace events whose slice name or args contain the given text |
 | `time-window` | Execute time window query |
 | `aggregate` | Execute aggregate query |
 | `ancestors` | Query ancestors of a slice |
@@ -140,6 +141,12 @@ The tools in this Skill can be invoked via the following CLI commands without ad
 
   ```bash
   $ node <path_to_the_skill>/scripts/trace_query.bundle.cjs id --id 381 --path "https://example.com/trace.pftrace"
+  ```
+
+- **Fuzzy-search trace events:**
+
+  ```bash
+  $ node <path_to_the_skill>/scripts/trace_query.bundle.cjs search --text 'loadBackground' --path "https://example.com/trace.pftrace"
   ```
 
 - **Query by time window:**

--- a/trace_analysis/skills/trace-analysis-skill/scripts/trace_query.bundle.cjs
+++ b/trace_analysis/skills/trace-analysis-skill/scripts/trace_query.bundle.cjs
@@ -15,6 +15,7 @@ const query_aggregate_1 = __webpack_require__(8536);
 const query_ancestors_1 = __webpack_require__(4473);
 const query_by_id_1 = __webpack_require__(880);
 const query_by_raw_sql_1 = __webpack_require__(7820);
+const query_by_search_text_1 = __webpack_require__(4203);
 const query_by_time_window_1 = __webpack_require__(1323);
 const query_descendants_1 = __webpack_require__(8051);
 const query_flow_events_1 = __webpack_require__(2363);
@@ -119,6 +120,18 @@ async function main() {
         const events = await (0, query_by_id_1.queryById)(tq, id);
         const result = (0, convert_trace_event_style_1.getTreeStyleTraceEvents)(events);
         console.log('Query result:', JSON.stringify(result, null, 2));
+    }));
+    program
+        .command('search')
+        .description('Search trace events by text')
+        .option('--text <text>', 'Search text')
+        .option('-p, --path <path>', 'Trace file path (can be URL or local file)')
+        .action(wrapCommandAction('search', async (options, traceQuery) => {
+        requireOption(options.path, 'path');
+        const text = requireOption(options.text, 'text');
+        const events = await (0, query_by_search_text_1.queryBySearchText)(traceQuery, text);
+        const result = (0, convert_trace_event_style_1.getTreeStyleTraceEvents)(events);
+        console.log('Search result:', JSON.stringify(result, null, 2));
     }));
     program
         .command('time-window')
@@ -390,6 +403,51 @@ async function queryByRawSql(traceQuery, sql) {
     return queryResult;
 }
 //# sourceMappingURL=query_by_raw_sql.js.map
+
+/***/ },
+
+/***/ 4203
+(__unused_webpack_module, exports, __webpack_require__) {
+
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.queryBySearchText = queryBySearchText;
+const parse_trace_event_1 = __webpack_require__(6331);
+function escapeSqlLiteral(value) {
+    return value.replace(/'/g, "''");
+}
+function escapeGlobPattern(value) {
+    return value.replace(/([*?\[])/g, '[$1]');
+}
+async function queryBySearchText(traceQuery, searchText) {
+    const trimmedSearchText = searchText.trim();
+    if (!trimmedSearchText) {
+        return [];
+    }
+    const normalizedSearchText = trimmedSearchText.toLowerCase();
+    const globPattern = `*${escapeSqlLiteral(escapeGlobPattern(normalizedSearchText))}*`;
+    const sql = 'WITH matched_slices AS ( ' +
+        'SELECT s.id ' +
+        'FROM slice s ' +
+        'LEFT JOIN args a ON s.arg_set_id = a.arg_set_id ' +
+        `WHERE lower(s.name) GLOB '${globPattern}' OR lower(a.string_value) GLOB '${globPattern}' OR lower(a.display_value) GLOB '${globPattern}' OR lower(a.key) GLOB '${globPattern}' ` +
+        'GROUP BY s.id ' +
+        ') ' +
+        'SELECT s.id, s.track_id, s.ts, s.dur, s.name, s.depth, t.name as thread_name, json_group_object(a.key, a.display_value) AS args ' +
+        'FROM matched_slices ms ' +
+        'JOIN slice s ON ms.id = s.id ' +
+        'LEFT JOIN args a ON s.arg_set_id = a.arg_set_id ' +
+        'JOIN thread_track tt ON s.track_id = tt.id ' +
+        'JOIN thread t ON tt.utid = t.utid ' +
+        'GROUP BY s.id, s.track_id, s.ts, s.dur, s.name, s.depth, t.name ' +
+        'ORDER BY s.ts';
+    const queryResult = await traceQuery.query(sql);
+    return (0, parse_trace_event_1.parseTraceEvent)(queryResult);
+}
+//# sourceMappingURL=query_by_search_text.js.map
 
 /***/ },
 


### PR DESCRIPTION
Add queryBySearchText function and search CLI command to fuzzy-search trace events by slice name and args fields. Uses case-insensitive GLOB matching against slice.name, args keys, string_value, and display_value.

Updates SKILL.md, README.md, skill_template.md, and bundled script with new API documentation and usage examples.