### PR TITLE
[Feature] Show fetch request URL in NativeModule track

### DIFF
--- a/ui/src/plugins/lynx.nativemodule/network_request_url_unittest.ts
+++ b/ui/src/plugins/lynx.nativemodule/network_request_url_unittest.ts
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {attachNetworkRequestUrlsToNativeModules} from './utils';
+
+describe('NativeModule network request URL association', () => {
+  it('attaches URL from a matching request inside the invoke range', () => {
+    const calls = [
+      {
+        ts: 100,
+        dur: 20,
+        flowId: 0,
+        moduleName: 'LynxFetchModule',
+        methodName: 'fetch',
+        url: '',
+      },
+    ];
+
+    attachNetworkRequestUrlsToNativeModules(calls, [
+      {
+        ts: 110,
+        flowId: 0,
+        moduleName: 'LynxFetchModule',
+        methodName: 'fetch',
+        url: 'https://example.com/model',
+      },
+    ]);
+
+    expect(calls[0].url).toBe('https://example.com/model');
+  });
+
+  it('prefers a same-flow request over a range match', () => {
+    const calls = [
+      {
+        ts: 100,
+        dur: 20,
+        flowId: 7,
+        moduleName: 'LynxFetchModule',
+        methodName: 'fetch',
+        url: '',
+      },
+    ];
+
+    attachNetworkRequestUrlsToNativeModules(calls, [
+      {
+        ts: 110,
+        flowId: 0,
+        moduleName: 'LynxFetchModule',
+        methodName: 'fetch',
+        url: 'https://example.com/range',
+      },
+      {
+        ts: 300,
+        flowId: 7,
+        moduleName: 'LynxFetchModule',
+        methodName: 'fetch',
+        url: 'https://example.com/flow',
+      },
+    ]);
+
+    expect(calls[0].url).toBe('https://example.com/flow');
+  });
+
+  it('does not attach unrelated nearby URLs', () => {
+    const calls = [
+      {
+        ts: 100,
+        dur: 20,
+        flowId: 0,
+        moduleName: 'LynxFetchModule',
+        methodName: 'fetch',
+        url: '',
+      },
+    ];
+
+    attachNetworkRequestUrlsToNativeModules(calls, [
+      {
+        ts: 110,
+        flowId: 0,
+        moduleName: 'runtimeBridge',
+        methodName: 'call',
+        url: 'https://example.com/app-fetch',
+      },
+    ]);
+
+    expect(calls[0].url).toBe('');
+  });
+});

--- a/ui/src/plugins/lynx.nativemodule/tracks.ts
+++ b/ui/src/plugins/lynx.nativemodule/tracks.ts
@@ -52,7 +52,10 @@ import {NativeModuleDetailsPanel} from './details';
 import {AppImpl} from '../../core/app_impl';
 import {getColorForSlice, UNEXPECTED_PINK} from '../../components/colorizer';
 import {formatDuration} from '../../components/time_utils';
-import {isNativeModuleCall} from './utils';
+import {
+  attachNetworkRequestUrlsToNativeModules,
+  isNativeModuleCall,
+} from './utils';
 import {stringToJsonObject} from '../../lynx_perf/string_utils';
 import {HSLColor} from '../../base/color';
 
@@ -137,6 +140,7 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
 
     const traceIdToJSBMap = new Map();
     const flowIdToTraceIdMap = new Map();
+    const networkRequestMap = new Map();
 
     let nativeModuleBeginTs = -1;
     let nativeModuleEndTs = -1;
@@ -165,6 +169,18 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
           callbackStartTs: 0,
         });
       }
+      if (
+        it.name === NATIVEMODULE_NETWORK_REQUEST &&
+        networkRequestMap.get(it.id) === undefined
+      ) {
+        networkRequestMap.set(it.id, {
+          ts: it.ts,
+          flowId: 0,
+          moduleName: '',
+          methodName: '',
+          url: '',
+        });
+      }
 
       if (
         isNativeModuleCall(it.name) &&
@@ -175,6 +191,16 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
         flowIdToTraceIdMap.set(flowId, it.id);
         const startJSB = traceIdToJSBMap.get(it.id);
         startJSB.flowId = flowId;
+      }
+      if (
+        it.name === NATIVEMODULE_NETWORK_REQUEST &&
+        it.key === 'debug.flowId' &&
+        it.intValue != null
+      ) {
+        const networkRequest = networkRequestMap.get(it.id);
+        if (networkRequest !== undefined) {
+          networkRequest.flowId = Number(it.intValue);
+        }
       }
 
       // In certain cases, "JSBTiming::Flush" may not exist. Here, we change the endpoint to the maximum of 'JSBTiming::jsb_func_platform_method_end' or 'JSBTiming::jsb_callback_call_end'.
@@ -212,8 +238,14 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
         it.key === 'debug.url'
       ) {
         const startJSB = traceIdToJSBMap.get(it.id);
-        startJSB.url = it.stringValue;
-        startJSB.firstArg = 'NetworkRequest';
+        if (startJSB !== undefined) {
+          startJSB.url = it.stringValue;
+          startJSB.firstArg = 'NetworkRequest';
+        }
+        const networkRequest = networkRequestMap.get(it.id);
+        if (networkRequest !== undefined) {
+          networkRequest.url = it.stringValue || '';
+        }
       } else if (it.key === 'debug.arg1') {
         try {
           const arg1 = JSON.parse(it.stringValue as string);
@@ -227,12 +259,28 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
         }
       } else if (it.key === 'debug.module_name') {
         const startJSB = traceIdToJSBMap.get(it.id);
-        startJSB.moduleName = it.stringValue;
+        if (startJSB !== undefined) {
+          startJSB.moduleName = it.stringValue;
+        }
+        const networkRequest = networkRequestMap.get(it.id);
+        if (networkRequest !== undefined) {
+          networkRequest.moduleName = it.stringValue || '';
+        }
       } else if (it.key === 'debug.method_name') {
         const startJSB = traceIdToJSBMap.get(it.id);
-        startJSB.methodName = it.stringValue;
+        if (startJSB !== undefined) {
+          startJSB.methodName = it.stringValue;
+        }
+        const networkRequest = networkRequestMap.get(it.id);
+        if (networkRequest !== undefined) {
+          networkRequest.methodName = it.stringValue || '';
+        }
       }
     }
+    attachNetworkRequestUrlsToNativeModules(
+      Array.from(traceIdToJSBMap.values()),
+      Array.from(networkRequestMap.values()),
+    );
     const sortedJsb = Array.from(traceIdToJSBMap.keys())
       .sort((a, b) => a - b)
       .map((key) => traceIdToJSBMap.get(key));
@@ -255,6 +303,7 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
     });
     traceIdToJSBMap.clear();
     flowIdToTraceIdMap.clear();
+    networkRequestMap.clear();
     return data;
   }
 
@@ -289,6 +338,7 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
 
     const traceIdToJSBMap = new Map();
     const flowIdToTraceIdMap = new Map();
+    const networkRequestMap = new Map();
 
     for (; it.valid(); it.next()) {
       if (
@@ -311,6 +361,18 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
           callbackStartTs: 0, // start ts of 'NATIVEMODULE_CALLBACK'
         });
       }
+      if (
+        it.name === NATIVEMODULE_NETWORK_REQUEST &&
+        networkRequestMap.get(it.id) === undefined
+      ) {
+        networkRequestMap.set(it.id, {
+          ts: it.ts,
+          flowId: 0,
+          moduleName: '',
+          methodName: '',
+          url: '',
+        });
+      }
 
       // update flowId
       if (
@@ -322,6 +384,16 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
         flowIdToTraceIdMap.set(flowId, it.id);
         const startJSB = traceIdToJSBMap.get(it.id);
         startJSB.flowId = flowId;
+      }
+      if (
+        it.name === NATIVEMODULE_NETWORK_REQUEST &&
+        it.key === 'debug.flowId' &&
+        it.intValue != null
+      ) {
+        const networkRequest = networkRequestMap.get(it.id);
+        if (networkRequest !== undefined) {
+          networkRequest.flowId = Number(it.intValue);
+        }
       }
 
       // update duration if possible
@@ -354,6 +426,10 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
           startJSB.url = it.stringValue;
           startJSB.firstArg = 'NetworkRequest';
         }
+        const networkRequest = networkRequestMap.get(it.id);
+        if (networkRequest !== undefined) {
+          networkRequest.url = it.stringValue || '';
+        }
       } else if (it.name === NATIVEMODULE_INVOKE && it.key === 'debug.arg1') {
         const arg1 = stringToJsonObject(it.stringValue as string);
         if (arg1.data !== undefined && arg1.data.url !== undefined) {
@@ -371,6 +447,14 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
           startJSB.moduleName = it.stringValue;
         }
       } else if (
+        it.name === NATIVEMODULE_NETWORK_REQUEST &&
+        it.key === 'debug.module_name'
+      ) {
+        const networkRequest = networkRequestMap.get(it.id);
+        if (networkRequest !== undefined) {
+          networkRequest.moduleName = it.stringValue || '';
+        }
+      } else if (
         it.name === NATIVEMODULE_INVOKE &&
         it.key === 'debug.method_name'
       ) {
@@ -378,8 +462,20 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
         if (startJSB !== undefined) {
           startJSB.methodName = it.stringValue;
         }
+      } else if (
+        it.name === NATIVEMODULE_NETWORK_REQUEST &&
+        it.key === 'debug.method_name'
+      ) {
+        const networkRequest = networkRequestMap.get(it.id);
+        if (networkRequest !== undefined) {
+          networkRequest.methodName = it.stringValue || '';
+        }
       }
     }
+    attachNetworkRequestUrlsToNativeModules(
+      Array.from(traceIdToJSBMap.values()),
+      Array.from(networkRequestMap.values()),
+    );
     const sortedJsb = Array.from(traceIdToJSBMap.keys())
       .sort((a, b) => a - b)
       .map((key) => traceIdToJSBMap.get(key));
@@ -402,6 +498,7 @@ export class LynxNativeModuleTrack extends LynxBaseTrack<NativeModuleItem[]> {
     });
     traceIdToJSBMap.clear();
     flowIdToTraceIdMap.clear();
+    networkRequestMap.clear();
     return data;
   }
 

--- a/ui/src/plugins/lynx.nativemodule/utils.ts
+++ b/ui/src/plugins/lynx.nativemodule/utils.ts
@@ -72,3 +72,70 @@ export function isNativeModuleCall(name: string) {
     name === NATIVEMODULE_NETWORK_REQUEST
   );
 }
+
+export interface NativeModuleCallInfo {
+  ts: number;
+  dur: number;
+  flowId: number;
+  moduleName: string;
+  methodName: string;
+  url: string;
+}
+
+export interface NativeModuleNetworkRequestInfo {
+  ts: number;
+  flowId: number;
+  moduleName: string;
+  methodName: string;
+  url: string;
+}
+
+function isSameNativeModule(
+  call: NativeModuleCallInfo,
+  request: NativeModuleNetworkRequestInfo,
+) {
+  return (
+    call.moduleName !== '' &&
+    call.methodName !== '' &&
+    call.moduleName === request.moduleName &&
+    call.methodName === request.methodName
+  );
+}
+
+function isRequestInCallRange(
+  call: NativeModuleCallInfo,
+  request: NativeModuleNetworkRequestInfo,
+) {
+  return request.ts >= call.ts && request.ts <= call.ts + call.dur;
+}
+
+export function attachNetworkRequestUrlsToNativeModules(
+  calls: NativeModuleCallInfo[],
+  requests: NativeModuleNetworkRequestInfo[],
+) {
+  for (const call of calls) {
+    if (call.url) {
+      continue;
+    }
+    const flowMatchedRequest = requests.find((request) => {
+      return (
+        request.url !== '' &&
+        call.flowId !== 0 &&
+        call.flowId === request.flowId &&
+        isSameNativeModule(call, request)
+      );
+    });
+    const rangeMatchedRequest =
+      flowMatchedRequest ??
+      requests.find((request) => {
+        return (
+          request.url !== '' &&
+          isSameNativeModule(call, request) &&
+          isRequestInCallRange(call, request)
+        );
+      });
+    if (rangeMatchedRequest !== undefined) {
+      call.url = rangeMatchedRequest.url;
+    }
+  }
+}


### PR DESCRIPTION
Associate Network::SendNetworkRequest trace events with matching NativeModule calls by flow ID or invoke time range, then append the request URL to the NativeModule item label.

TEST: ./ui/build
TEST: ./ui/run-unittests --no-build --test-filter "NativeModule network request URL association"
TEST: git diff --check

issue: #99 